### PR TITLE
Validate max number of reserves in /liquidity_pools endpoint

### DIFF
--- a/internal/actions/liquidity_pool.go
+++ b/internal/actions/liquidity_pool.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -15,6 +16,11 @@ import (
 	"github.com/stellar/stellar-horizon/internal/ledger"
 	"github.com/stellar/stellar-horizon/internal/resourceadapter"
 )
+
+// A liquidity pool has exactly two reserve assets, so any filter value above
+// two can only match zero pools while still forcing the server to allocate and
+// build an oversized SQL query.
+const maxLiquidityPoolReserves = 2
 
 // GetLiquidityPoolByIDHandler is the action handler for all end-points returning a liquidity pool.
 type GetLiquidityPoolByIDHandler struct{}
@@ -73,6 +79,14 @@ func (q LiquidityPoolsQuery) URITemplate() string {
 
 // Validate validates and parses the query
 func (q *LiquidityPoolsQuery) Validate() error {
+	// Reject over-long inputs before calling strings.Split, which would
+	// otherwise allocate a slice proportional to the number of commas.
+	if strings.Count(q.Reserves, ",")+1 > maxLiquidityPoolReserves {
+		return problem.MakeInvalidFieldProblem(
+			"reserves",
+			fmt.Errorf("reserves exceeds maximum length of %d", maxLiquidityPoolReserves),
+		)
+	}
 	assets := []xdr.Asset{}
 	reserves := strings.Split(q.Reserves, ",")
 	reservesErr := problem.MakeInvalidFieldProblem(

--- a/internal/actions/liquidity_pool_test.go
+++ b/internal/actions/liquidity_pool_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stellar/go-stellar-sdk/keypair"
@@ -14,6 +15,35 @@ import (
 	"github.com/stellar/stellar-horizon/internal/test"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestLiquidityPoolsQueryValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		reserves string
+		wantErr  bool
+	}{
+		{name: "empty", reserves: "", wantErr: false},
+		{name: "one reserve", reserves: "native", wantErr: false},
+		{name: "two reserves", reserves: "native," + usdAsset.StringCanonical(), wantErr: false},
+		{name: "three natives rejected", reserves: "native,native,native", wantErr: true},
+		{name: "three mixed assets rejected", reserves: "native," + usdAsset.StringCanonical() + "," + eurAsset.StringCanonical(), wantErr: true},
+		{name: "long attack payload rejected", reserves: strings.Repeat("native,", 10000) + "native", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := LiquidityPoolsQuery{Reserves: tc.reserves}
+			err := q.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+				p, ok := err.(*problem.P)
+				assert.True(t, ok, "expected *problem.P, got %T", err)
+				assert.Equal(t, "reserves", p.Extras["invalid_field"])
+				assert.Contains(t, p.Extras["reason"], "maximum length of 2")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestGetLiquidityPoolByID(t *testing.T) {
 	tt := test.Start(t)


### PR DESCRIPTION
## Summary

- A liquidity pool holds exactly two reserve assets, so the `reserves` filter on `/liquidity_pools` can only meaningfully accept up to two values. Anything beyond that trivially matches zero pools.
- This change rejects requests with more than two reserves up front with a clear `bad_request` problem, instead of building a SQL query that is guaranteed to return no results regardless of input.
- The check runs before `strings.Split` so the work stays proportional to the valid case, not the request size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
