### PR TITLE
Return structured errors from filter parsing in query endpoints

### DIFF
--- a/internal/actions/account.go
+++ b/internal/actions/account.go
@@ -96,7 +96,11 @@ func (q AccountsQuery) Validate() error {
 		)
 	}
 
-	numParams, err := countNonEmpty(q.Sponsor, q.Signer, q.Asset(), q.LiquidityPool)
+	asset, err := q.Asset()
+	if err != nil {
+		return err
+	}
+	numParams, err := countNonEmpty(q.Sponsor, q.Signer, asset, q.LiquidityPool)
 	if err != nil {
 		return errors.Wrap(err, "Could not count request params")
 	}
@@ -108,15 +112,22 @@ func (q AccountsQuery) Validate() error {
 }
 
 // Asset returns an xdr.Asset representing the Asset we want to find the trustees by.
-func (q AccountsQuery) Asset() *xdr.Asset {
+// The native asset is rejected by Validate above with a specific error message, so
+// this method does not special-case "native"; it is treated as a malformed filter
+// (single token, no colon) and returns the generic asset-format error.
+func (q AccountsQuery) Asset() (*xdr.Asset, error) {
 	if len(q.AssetFilter) == 0 {
-		return nil
+		return nil, nil
 	}
-
 	parts := strings.Split(q.AssetFilter, ":")
-	asset := xdr.MustNewCreditAsset(parts[0], parts[1])
-
-	return &asset
+	if len(parts) != 2 {
+		return nil, problem.MakeInvalidFieldProblem("asset", errors.New(customTagsErrorMessages["asset"]))
+	}
+	asset, err := xdr.NewCreditAsset(parts[0], parts[1])
+	if err != nil {
+		return nil, problem.MakeInvalidFieldProblem("asset", err)
+	}
+	return &asset, nil
 }
 
 // GetAccountsHandler is the action handler for the /accounts endpoint
@@ -166,7 +177,15 @@ func (handler GetAccountsHandler) GetResourcePage(
 			return nil, errors.Wrap(err, "loading account records")
 		}
 	} else {
-		records, err = historyQ.AccountsForAsset(ctx, *qp.Asset(), pq)
+		var asset *xdr.Asset
+		asset, err = qp.Asset()
+		if err != nil {
+			return nil, err
+		}
+		if asset == nil {
+			return nil, invalidAccountsParams
+		}
+		records, err = historyQ.AccountsForAsset(ctx, *asset, pq)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading account records")
 		}

--- a/internal/actions/account_test.go
+++ b/internal/actions/account_test.go
@@ -20,6 +20,46 @@ import (
 	"github.com/stellar/stellar-horizon/internal/test"
 )
 
+func TestAccountsQueryAsset(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		filter  string
+		wantNil bool
+		wantErr bool
+	}{
+		{name: "empty", filter: "", wantNil: true, wantErr: false},
+		{name: "valid credit", filter: "USD:" + trustLineIssuer, wantNil: false, wantErr: false},
+		{name: "lowercase native rejected", filter: "native", wantNil: true, wantErr: true},
+		{name: "mixed-case native rejected", filter: "Native", wantNil: true, wantErr: true},
+		{name: "uppercase native rejected", filter: "NATIVE", wantNil: true, wantErr: true},
+		{name: "no colon", filter: "noColon", wantNil: true, wantErr: true},
+		{name: "bare colon", filter: ":", wantNil: true, wantErr: true},
+		{name: "missing issuer", filter: "A:", wantNil: true, wantErr: true},
+		{name: "missing code", filter: ":B", wantNil: true, wantErr: true},
+		{name: "extra colons", filter: "too:many:colons", wantNil: true, wantErr: true},
+		{name: "invalid issuer", filter: "USD:not-an-address", wantNil: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := AccountsQuery{AssetFilter: tc.filter}
+			var (
+				asset *xdr.Asset
+				err   error
+			)
+			assert.NotPanics(t, func() { asset, err = q.Asset() })
+			if tc.wantNil {
+				assert.Nil(t, asset)
+			} else {
+				assert.NotNil(t, asset)
+			}
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 var (
 	trustLineIssuer = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
 	accountOne      = "GABGMPEKKDWR2WFH5AJOZV5PDKLJEHGCR3Q24ALETWR5H3A7GI3YTS7V"

--- a/internal/actions/claimable_balance.go
+++ b/internal/actions/claimable_balance.go
@@ -69,33 +69,45 @@ type ClaimableBalancesQuery struct {
 	ClaimantFilter string `schema:"claimant" valid:"accountID,optional"`
 }
 
-func (q ClaimableBalancesQuery) asset() *xdr.Asset {
-	if len(q.AssetFilter) > 0 {
-		switch q.AssetFilter {
-		case "native":
-			asset := xdr.MustNewNativeAsset()
-			return &asset
-		default:
-			parts := strings.Split(q.AssetFilter, ":")
-			asset := xdr.MustNewCreditAsset(parts[0], parts[1])
-			return &asset
-		}
+func (q ClaimableBalancesQuery) asset() (*xdr.Asset, error) {
+	if len(q.AssetFilter) == 0 {
+		return nil, nil
 	}
-	return nil
+	if q.AssetFilter == "native" {
+		asset := xdr.MustNewNativeAsset()
+		return &asset, nil
+	}
+	parts := strings.Split(q.AssetFilter, ":")
+	if len(parts) != 2 {
+		return nil, problem.MakeInvalidFieldProblem("asset", errors.New(customTagsErrorMessages["asset"]))
+	}
+	asset, err := xdr.NewCreditAsset(parts[0], parts[1])
+	if err != nil {
+		return nil, problem.MakeInvalidFieldProblem("asset", err)
+	}
+	return &asset, nil
 }
 
-func (q ClaimableBalancesQuery) sponsor() *xdr.AccountId {
-	if q.SponsorFilter != "" {
-		return xdr.MustAddressPtr(q.SponsorFilter)
+func (q ClaimableBalancesQuery) sponsor() (*xdr.AccountId, error) {
+	if q.SponsorFilter == "" {
+		return nil, nil
 	}
-	return nil
+	accountID, err := xdr.AddressToAccountId(q.SponsorFilter)
+	if err != nil {
+		return nil, problem.MakeInvalidFieldProblem("sponsor", err)
+	}
+	return &accountID, nil
 }
 
-func (q ClaimableBalancesQuery) claimant() *xdr.AccountId {
-	if q.ClaimantFilter != "" {
-		return xdr.MustAddressPtr(q.ClaimantFilter)
+func (q ClaimableBalancesQuery) claimant() (*xdr.AccountId, error) {
+	if q.ClaimantFilter == "" {
+		return nil, nil
 	}
-	return nil
+	accountID, err := xdr.AddressToAccountId(q.ClaimantFilter)
+	if err != nil {
+		return nil, problem.MakeInvalidFieldProblem("claimant", err)
+	}
+	return &accountID, nil
 }
 
 // URITemplate returns a rfc6570 URI template the query struct
@@ -124,11 +136,23 @@ func (handler GetClaimableBalancesHandler) GetResourcePage(
 		return nil, err
 	}
 
+	asset, err := qp.asset()
+	if err != nil {
+		return nil, err
+	}
+	sponsor, err := qp.sponsor()
+	if err != nil {
+		return nil, err
+	}
+	claimant, err := qp.claimant()
+	if err != nil {
+		return nil, err
+	}
 	query := history.ClaimableBalancesQuery{
 		PageQuery: pq,
-		Asset:     qp.asset(),
-		Sponsor:   qp.sponsor(),
-		Claimant:  qp.claimant(),
+		Asset:     asset,
+		Sponsor:   sponsor,
+		Claimant:  claimant,
 	}
 
 	_, _, err = query.Cursor()

--- a/internal/actions/claimable_balance_test.go
+++ b/internal/actions/claimable_balance_test.go
@@ -15,6 +15,117 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestClaimableBalancesQueryAsset(t *testing.T) {
+	issuer := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+	for _, tc := range []struct {
+		name    string
+		filter  string
+		wantNil bool
+		wantErr bool
+	}{
+		{name: "empty", filter: "", wantNil: true, wantErr: false},
+		{name: "native", filter: "native", wantNil: false, wantErr: false},
+		{name: "valid credit", filter: "USD:" + issuer, wantNil: false, wantErr: false},
+		{name: "mixed-case native rejected", filter: "Native", wantNil: true, wantErr: true},
+		{name: "uppercase native rejected", filter: "NATIVE", wantNil: true, wantErr: true},
+		{name: "no colon", filter: "noColon", wantNil: true, wantErr: true},
+		{name: "bare colon", filter: ":", wantNil: true, wantErr: true},
+		{name: "missing issuer", filter: "A:", wantNil: true, wantErr: true},
+		{name: "missing code", filter: ":B", wantNil: true, wantErr: true},
+		{name: "extra colons", filter: "too:many:colons", wantNil: true, wantErr: true},
+		{name: "invalid issuer", filter: "USD:not-an-address", wantNil: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := ClaimableBalancesQuery{AssetFilter: tc.filter}
+			var (
+				asset *xdr.Asset
+				err   error
+			)
+			assert.NotPanics(t, func() { asset, err = q.asset() })
+			if tc.wantNil {
+				assert.Nil(t, asset)
+			} else {
+				assert.NotNil(t, asset)
+			}
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestClaimableBalancesQuerySponsor(t *testing.T) {
+	validAddress := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+	for _, tc := range []struct {
+		name    string
+		sponsor string
+		wantNil bool
+		wantErr bool
+	}{
+		{name: "empty", sponsor: "", wantNil: true, wantErr: false},
+		{name: "valid address", sponsor: validAddress, wantNil: false, wantErr: false},
+		{name: "invalid address", sponsor: "not-an-address", wantNil: true, wantErr: true},
+		{name: "wrong prefix", sponsor: "AXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", wantNil: true, wantErr: true},
+		{name: "bare G", sponsor: "G", wantNil: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := ClaimableBalancesQuery{SponsorFilter: tc.sponsor}
+			var (
+				account *xdr.AccountId
+				err     error
+			)
+			assert.NotPanics(t, func() { account, err = q.sponsor() })
+			if tc.wantNil {
+				assert.Nil(t, account)
+			} else {
+				assert.NotNil(t, account)
+			}
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestClaimableBalancesQueryClaimant(t *testing.T) {
+	validAddress := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+	for _, tc := range []struct {
+		name     string
+		claimant string
+		wantNil  bool
+		wantErr  bool
+	}{
+		{name: "empty", claimant: "", wantNil: true, wantErr: false},
+		{name: "valid address", claimant: validAddress, wantNil: false, wantErr: false},
+		{name: "invalid address", claimant: "not-an-address", wantNil: true, wantErr: true},
+		{name: "wrong prefix", claimant: "AXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", wantNil: true, wantErr: true},
+		{name: "bare G", claimant: "G", wantNil: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := ClaimableBalancesQuery{ClaimantFilter: tc.claimant}
+			var (
+				account *xdr.AccountId
+				err     error
+			)
+			assert.NotPanics(t, func() { account, err = q.claimant() })
+			if tc.wantNil {
+				assert.Nil(t, account)
+			} else {
+				assert.NotNil(t, account)
+			}
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGetClaimableBalanceByID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()

--- a/internal/actions/path.go
+++ b/internal/actions/path.go
@@ -46,26 +46,25 @@ func (q StrictReceivePathsQuery) Assets() ([]xdr.Asset, error) {
 }
 
 // Amount returns source amount
-func (q StrictReceivePathsQuery) Amount() xdr.Int64 {
+func (q StrictReceivePathsQuery) Amount() (xdr.Int64, error) {
 	parsed, err := amount.Parse(q.DestinationAmount)
 	if err != nil {
-		panic(err)
+		return 0, problem.MakeInvalidFieldProblem("destination_amount", err)
 	}
-	return parsed
+	return parsed, nil
 }
 
 // DestinationAsset returns an xdr.Asset
-func (q StrictReceivePathsQuery) DestinationAsset() xdr.Asset {
+func (q StrictReceivePathsQuery) DestinationAsset() (xdr.Asset, error) {
 	asset, err := xdr.BuildAsset(
 		q.DestinationAssetType,
 		q.DestinationAssetIssuer,
 		q.DestinationAssetCode,
 	)
 	if err != nil {
-		panic(err)
+		return xdr.Asset{}, problem.MakeInvalidFieldProblem("destination_asset", err)
 	}
-
-	return asset
+	return asset, nil
 }
 
 // URITemplate returns a rfc6570 URI template for the query struct
@@ -120,7 +119,10 @@ func (handler FindPathsHandler) GetResource(w HeaderWriter, r *http.Request) (in
 	}
 
 	query := paths.Query{}
-	query.DestinationAmount = qp.Amount()
+	query.DestinationAmount, err = qp.Amount()
+	if err != nil {
+		return nil, err
+	}
 	sourceAccount := qp.SourceAccount
 	query.SourceAssets, _ = qp.Assets()
 
@@ -130,7 +132,10 @@ func (handler FindPathsHandler) GetResource(w HeaderWriter, r *http.Request) (in
 			fmt.Errorf("list of assets exceeds maximum length of %d", handler.MaxAssetsParamLength),
 		)
 	}
-	query.DestinationAsset = qp.DestinationAsset()
+	query.DestinationAsset, err = qp.DestinationAsset()
+	if err != nil {
+		return nil, err
+	}
 	if sourceAccount != "" {
 		var accountID xdr.AccountId
 		accountID, err = xdr.AddressToAccountId(sourceAccount)
@@ -268,26 +273,25 @@ func (q FindFixedPathsQuery) Assets() ([]xdr.Asset, error) {
 }
 
 // Amount returns source amount
-func (q FindFixedPathsQuery) Amount() xdr.Int64 {
+func (q FindFixedPathsQuery) Amount() (xdr.Int64, error) {
 	parsed, err := amount.Parse(q.SourceAmount)
 	if err != nil {
-		panic(err)
+		return 0, problem.MakeInvalidFieldProblem("source_amount", err)
 	}
-	return parsed
+	return parsed, nil
 }
 
 // SourceAsset returns an xdr.Asset
-func (q FindFixedPathsQuery) SourceAsset() xdr.Asset {
+func (q FindFixedPathsQuery) SourceAsset() (xdr.Asset, error) {
 	asset, err := xdr.BuildAsset(
 		q.SourceAssetType,
 		q.SourceAssetIssuer,
 		q.SourceAssetCode,
 	)
 	if err != nil {
-		panic(err)
+		return xdr.Asset{}, problem.MakeInvalidFieldProblem("source_asset", err)
 	}
-
-	return asset
+	return asset, nil
 }
 
 // GetResource returns a list of strict send paths
@@ -329,8 +333,14 @@ func (handler FindFixedPathsHandler) GetResource(w HeaderWriter, r *http.Request
 		return nil, errors.Wrap(err, "error in rollback")
 	}
 
-	sourceAsset := qp.SourceAsset()
-	amountToSpend := qp.Amount()
+	sourceAsset, err := qp.SourceAsset()
+	if err != nil {
+		return nil, err
+	}
+	amountToSpend, err := qp.Amount()
+	if err != nil {
+		return nil, err
+	}
 
 	records := []paths.Path{}
 	if len(destinationAssets) > 0 {

--- a/internal/actions/path.go
+++ b/internal/actions/path.go
@@ -132,8 +132,12 @@ func (handler FindPathsHandler) GetResource(w HeaderWriter, r *http.Request) (in
 	}
 	query.DestinationAsset = qp.DestinationAsset()
 	if sourceAccount != "" {
-		sourceAccount := xdr.MustAddress(sourceAccount)
-		query.SourceAccount = &sourceAccount
+		var accountID xdr.AccountId
+		accountID, err = xdr.AddressToAccountId(sourceAccount)
+		if err != nil {
+			return nil, problem.MakeInvalidFieldProblem("source_account", err)
+		}
+		query.SourceAccount = &accountID
 		query.ValidateSourceBalance = true
 		query.SourceAssets, query.SourceAssetBalances, err = assetsForAddressWithLimit(
 			r, query.SourceAccount.Address(), handler.MaxAssetsParamLength,

--- a/internal/actions/path_test.go
+++ b/internal/actions/path_test.go
@@ -18,6 +18,114 @@ var (
 	maxAssetsParamLength = 2
 )
 
+func TestStrictReceivePathsQueryAmount(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		amount  string
+		wantErr bool
+	}{
+		{name: "valid", amount: "10.0", wantErr: false},
+		{name: "empty", amount: "", wantErr: true},
+		{name: "not a number", amount: "abc", wantErr: true},
+		{name: "malformed decimal", amount: "1.2.3", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := StrictReceivePathsQuery{DestinationAmount: tc.amount}
+			var err error
+			assert.NotPanics(t, func() { _, err = q.Amount() })
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStrictReceivePathsQueryDestinationAsset(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		assetType string
+		code      string
+		issuer    string
+		wantErr   bool
+	}{
+		{name: "native", assetType: "native", wantErr: false},
+		{name: "credit", assetType: "credit_alphanum4", code: "USD", issuer: dummyIssuer, wantErr: false},
+		{name: "invalid type", assetType: "garbage", wantErr: true},
+		{name: "bad issuer", assetType: "credit_alphanum4", code: "USD", issuer: "not-an-address", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := StrictReceivePathsQuery{
+				DestinationAssetType:   tc.assetType,
+				DestinationAssetCode:   tc.code,
+				DestinationAssetIssuer: tc.issuer,
+			}
+			var err error
+			assert.NotPanics(t, func() { _, err = q.DestinationAsset() })
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFindFixedPathsQueryAmount(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		amount  string
+		wantErr bool
+	}{
+		{name: "valid", amount: "10.0", wantErr: false},
+		{name: "empty", amount: "", wantErr: true},
+		{name: "not a number", amount: "abc", wantErr: true},
+		{name: "malformed decimal", amount: "1.2.3", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := FindFixedPathsQuery{SourceAmount: tc.amount}
+			var err error
+			assert.NotPanics(t, func() { _, err = q.Amount() })
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFindFixedPathsQuerySourceAsset(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		assetType string
+		code      string
+		issuer    string
+		wantErr   bool
+	}{
+		{name: "native", assetType: "native", wantErr: false},
+		{name: "credit", assetType: "credit_alphanum4", code: "USD", issuer: dummyIssuer, wantErr: false},
+		{name: "invalid type", assetType: "garbage", wantErr: true},
+		{name: "bad issuer", assetType: "credit_alphanum4", code: "USD", issuer: "not-an-address", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := FindFixedPathsQuery{
+				SourceAssetType:   tc.assetType,
+				SourceAssetCode:   tc.code,
+				SourceAssetIssuer: tc.issuer,
+			}
+			var err error
+			assert.NotPanics(t, func() { _, err = q.SourceAsset() })
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestAssetsForAddressRequiresTransaction(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()

--- a/internal/actions/validators.go
+++ b/internal/actions/validators.go
@@ -55,7 +55,7 @@ func isTradeType(tradeType string) bool {
 func isAsset(assetString string) bool {
 	var asset xdr.Asset
 
-	if strings.ToLower(assetString) == "native" {
+	if assetString == "native" {
 		if err := asset.SetNative(); err != nil {
 			return false
 		}

--- a/internal/actions/validators_test.go
+++ b/internal/actions/validators_test.go
@@ -2,11 +2,52 @@ package actions
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/stellar/go-stellar-sdk/support/render/problem"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestAssetFilterMixedCaseNativeRejected is a regression test for the panic
+// previously triggered by asset=Native on /accounts and /claimable_balances.
+// It exercises the full getParams pipeline (schema decode -> govalidator ->
+// Validateable.Validate) and verifies a 400 problem.P is returned instead of
+// a panic. If isAsset is ever loosened, or the valid:"asset" tag is ever
+// dropped from these struct fields, this test fails.
+func TestAssetFilterMixedCaseNativeRejected(t *testing.T) {
+	for _, variant := range []string{"Native", "NATIVE", "nAtIvE"} {
+		t.Run("claimable_balances/"+variant, func(t *testing.T) {
+			q := ClaimableBalancesQuery{}
+			r := makeRequest(t, map[string]string{"asset": variant}, map[string]string{}, nil)
+			assert.NotPanics(t, func() {
+				err := getParams(&q, r)
+				assert.Error(t, err)
+				p, ok := err.(*problem.P)
+				assert.True(t, ok, "expected *problem.P, got %T", err)
+				if ok {
+					assert.Equal(t, http.StatusBadRequest, p.Status)
+					assert.Equal(t, "asset", p.Extras["invalid_field"])
+				}
+			})
+		})
+		t.Run("accounts/"+variant, func(t *testing.T) {
+			q := AccountsQuery{}
+			r := makeRequest(t, map[string]string{"asset": variant}, map[string]string{}, nil)
+			assert.NotPanics(t, func() {
+				err := getParams(&q, r)
+				assert.Error(t, err)
+				p, ok := err.(*problem.P)
+				assert.True(t, ok, "expected *problem.P, got %T", err)
+				if ok {
+					assert.Equal(t, http.StatusBadRequest, p.Status)
+					assert.Equal(t, "asset", p.Extras["invalid_field"])
+				}
+			})
+		})
+	}
+}
 
 func TestAssetTypeValidator(t *testing.T) {
 	type Query struct {
@@ -143,6 +184,16 @@ func TestAssetValidator(t *testing.T) {
 		{
 			"empty colon",
 			":",
+			false,
+		},
+		{
+			"mixed-case native rejected",
+			"Native",
+			false,
+		},
+		{
+			"uppercase native rejected",
+			"NATIVE",
 			false,
 		},
 	} {


### PR DESCRIPTION
## Summary

Several methods in `internal/actions` relied on `xdr.Must*`, `xdr.BuildAsset`, or `amount.Parse` panicking on user-controlled input, trusting an upstream validator to keep that path unreachable. The coupling is fragile: any future change to the validator can reintroduce a panic in the parser.

This change reworks those parsers to return `(value, error)` with explicit bounds checks and non-panicking constructors, and threads the error through the handlers as a `bad_request` problem with a matching field name. The nearby `/offers` code in `query_params.go` already followed this pattern — this change brings the remaining sites into consistency.

Affected methods:

- `ClaimableBalancesQuery.asset` / `sponsor` / `claimant`
- `AccountsQuery.Asset`
- `StrictReceivePathsQuery.Amount` / `DestinationAsset` and the strict-receive `source_account` branch
- `FindFixedPathsQuery.Amount` / `SourceAsset`

`isAsset` also now matches only the canonical lowercase `native` string (per SEP-11) instead of any case variant, keeping validator acceptance and parser switch-on-`"native"` in sync.

## Notes

- API-visible behavior change: `selling=Native` / `buying=Native` on `/offers` and `/order_book` previously returned a 400 with reason `"missing colon"` from `Selling()/Buying()`. They now return a 400 with the standard `isAsset` reason. Status code unchanged; reason text differs. No clients should depend on the specific reason string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
