### PR TITLE
Bump protocol 26 core version to 27.0.0-3288.7696c069d

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -35,8 +35,8 @@ jobs:
       PROTOCOL_25_CORE_DEBIAN_PKG_VERSION: 25.2.0-3058.bb195c49d.noble~buildtests
       PROTOCOL_25_CORE_DOCKER_IMG: stellar/stellar-core:25.2.0-3058.bb195c49d.noble
       PROTOCOL_25_STELLAR_RPC_DOCKER_IMG: stellar/stellar-rpc:26.0.0-testing-185
-      PROTOCOL_26_CORE_DOCKER_IMG: stellar/stellar-core:25.2.1-3069.73babfde9.noble
-      PROTOCOL_26_CORE_DEBIAN_PKG_VERSION: 25.2.1-3069.73babfde9.noble~buildtests
+      PROTOCOL_26_CORE_DOCKER_IMG: stellar/stellar-core:27.0.0-3288.7696c069d.jammy
+      PROTOCOL_26_CORE_DEBIAN_PKG_VERSION: 27.0.0-3288.7696c069d.jammy~buildtests
       PROTOCOL_26_STELLAR_RPC_DOCKER_IMG: stellar/stellar-rpc:26.0.0-testing-185
       PGHOST: localhost
       PGPORT: 5432
@@ -82,6 +82,11 @@ jobs:
         run: |
           sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
           sudo bash -c 'echo "deb https://apt.stellar.org noble unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
+          # The 27.0.0 core build is only published for jammy, so add the jammy unstable repo as well,
+          # plus the LLVM-20 jammy repo for its libc++1/libc++abi1/libunwind runtime dependencies.
+          sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" >> /etc/apt/sources.list.d/SDF-unstable.list'
+          sudo wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
+          sudo bash -c 'echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm-jammy.list'
           sudo apt-get update && sudo apt-get install -y stellar-core="$PROTOCOL_${{ matrix.protocol-version }}_CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"
           echo 'HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_BIN=/usr/bin/stellar-core' >> $GITHUB_ENV

--- a/internal/integration/generate_ledgers_test.go
+++ b/internal/integration/generate_ledgers_test.go
@@ -30,10 +30,11 @@ import (
 //   - HORIZON_INTEGRATION_TESTS_ENABLED=true
 //
 // Optional env vars:
-//   - HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: Path to stellar-core 25.x with BUILD_TESTS enabled
-//     (default: looks for "stellar-core" in PATH)
+//   - HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: Path to stellar-core 25.x or newer with
+//     BUILD_TESTS enabled (default: looks for "stellar-core" in PATH)
 //   - LOADTEST_CORE_CONFIG_PATH: Path to custom apply-load config file
-//     (default: testdata/apply-load.cfg)
+//     (default: testdata/apply-load.cfg for stellar-core < 27,
+//     testdata/apply-load-v27.cfg otherwise)
 //   - LOADTEST_OUTPUT_PATH: Destination path for compressed ledger XDR output
 //     (default: empty, no file written)
 //   - LOADTEST_FIXTURES_PATH: Destination path for compressed fixtures XDR output
@@ -55,10 +56,22 @@ func TestGenerateLedgers(t *testing.T) {
 	coreVersion, err := ledgerbackend.CoreBuildVersion(coreBinaryPath)
 	require.NoError(t, err)
 
-	// Use custom config if provided, otherwise use default
+	// The apply-load command runs at the core's current ledger protocol version,
+	// which may be greater than HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL.
+	coreProtocolVersion, err := ledgerbackend.CoreProtocolVersion(coreBinaryPath)
+	require.NoError(t, err)
+
+	// Use custom config if provided, otherwise use a default based on the core
+	// version. Core 27 reworked the apply-load configuration (removed the sampled
+	// APPLY_LOAD_* load parameters in favor of APPLY_LOAD_MODE), so older configs
+	// fail to parse on newer cores and vice versa.
 	configPath := os.Getenv("LOADTEST_CORE_CONFIG_PATH")
 	if configPath == "" {
-		configPath = "testdata/apply-load.cfg"
+		if coreMajorVersion(t, coreVersion) >= 27 {
+			configPath = "testdata/apply-load-v27.cfg"
+		} else {
+			configPath = "testdata/apply-load.cfg"
+		}
 	}
 
 	outputPath := os.Getenv("LOADTEST_OUTPUT_PATH")
@@ -77,7 +90,7 @@ func TestGenerateLedgers(t *testing.T) {
 
 	t.Log("Verifying fixtures completeness...")
 	metadataPath := filepath.Join(workDir, cfg.MetadataOutputStream)
-	verifyFixturesCompleteness(t, workDir, metadataPath, cfg.NetworkPassphrase, preBenchmarkCheckpoint)
+	verifyFixturesCompleteness(t, workDir, metadataPath, cfg.NetworkPassphrase, preBenchmarkCheckpoint, coreProtocolVersion)
 
 	// Stream ledgers to output file, or just count them for verification
 	// Only include benchmark ledgers (after the pre-benchmark checkpoint),
@@ -95,6 +108,17 @@ func TestGenerateLedgers(t *testing.T) {
 		count := streamFixturesToFile(t, workDir, cfg.NetworkPassphrase, preBenchmarkCheckpoint, fixturesPath)
 		t.Logf("Wrote %d ledger entry fixtures", count)
 	}
+}
+
+// coreMajorVersion extracts the major version from the output of
+// "stellar-core version", e.g. "stellar-core 27.0.0 (7696c069d...)" -> 27.
+func coreMajorVersion(t *testing.T, coreVersion string) int {
+	re := regexp.MustCompile(`(\d+)\.\d+\.\d+`)
+	matches := re.FindStringSubmatch(coreVersion)
+	require.NotNil(t, matches, "could not parse major version from %q", coreVersion)
+	major, err := strconv.Atoi(matches[1])
+	require.NoError(t, err)
+	return major
 }
 
 func runApplyLoad(t *testing.T, coreBinaryPath, configPath string, cfg applyLoadConfig) (string, uint32) {
@@ -304,7 +328,7 @@ func copyFile(t *testing.T, src, dst string) {
 	require.NoError(t, os.WriteFile(dst, data, 0644))
 }
 
-func verifyFixturesCompleteness(t *testing.T, workDir, metadataPath, networkPassphrase string, checkpointLedger uint32) {
+func verifyFixturesCompleteness(t *testing.T, workDir, metadataPath, networkPassphrase string, checkpointLedger uint32, coreProtocolVersion uint) {
 	// Step 1: Load all ledger entry keys from fixtures into a set
 	knownKeys := make(map[string]bool)
 	checkpointReader := openCheckpointReader(t, workDir, networkPassphrase, checkpointLedger)
@@ -340,7 +364,10 @@ func verifyFixturesCompleteness(t *testing.T, workDir, metadataPath, networkPass
 		} else {
 			require.NoError(t, err)
 		}
-		require.True(t, ledger.ProtocolVersion() == integration.GetCoreMaxSupportedProtocol())
+		// apply-load runs at the core's current ledger protocol version, which may
+		// exceed HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL (e.g. an
+		// unreleased core whose current protocol is one past the max supported one).
+		require.Equal(t, uint32(coreProtocolVersion), ledger.ProtocolVersion())
 
 		// Extract changes from this ledger
 		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(networkPassphrase, ledger)

--- a/internal/integration/testdata/apply-load-v27.cfg
+++ b/internal/integration/testdata/apply-load-v27.cfg
@@ -1,0 +1,113 @@
+# Apply-load configuration for TestGenerateLedgers when using stellar-core >= 27.
+#
+# Core 27 reworked the apply-load configuration: load generation parameters like
+# APPLY_LOAD_INSTRUCTIONS / APPLY_LOAD_TX_SIZE_BYTES / APPLY_LOAD_NUM_RW_ENTRIES
+# were removed in favor of an APPLY_LOAD_MODE selector, and the apply-load command
+# now force-overrides NETWORK_PASSPHRASE to "Apply Load" and LEDGER_PROTOCOL_VERSION
+# to the core's current protocol.
+#
+# Based on: https://github.com/stellar/stellar-core/blob/7696c069d720fb450caeae940769b0a78a157363/docs/apply-load-for-meta.cfg
+# Override with LOADTEST_CORE_CONFIG_PATH env var for custom configurations.
+#
+# Differences from upstream:
+#   - LOG_FILE_PATH: "" (log to stdout so we can parse the pre-benchmark checkpoint)
+#   - APPLY_LOAD_NUM_LEDGERS: 30 (instead of 100, for faster test runs; 30 is core minimum)
+#   - APPLY_LOAD_CLASSIC_TXS_PER_LEDGER: 10 (instead of 1000, to keep fixture files small)
+
+# Select the apply-load mode. The "ledger-limits" mode is the one that publishes
+# the pre-benchmark history checkpoint the test relies on.
+APPLY_LOAD_MODE="ledger-limits"
+
+# Custom meta path - if not set it will be written to a temp directory and
+# cleaned up after running the benchmark
+METADATA_OUTPUT_STREAM='meta.xdr'
+
+# Network configuration to use during the benchmark
+# The fields here correspond to the network configuration settings.
+APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS = 580000000
+APPLY_LOAD_TX_MAX_INSTRUCTIONS = 400000000
+
+APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 2
+
+APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = 400
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES = 200
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES = 400000
+APPLY_LOAD_TX_MAX_DISK_READ_BYTES = 200000
+
+APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES = 200
+
+APPLY_LOAD_LEDGER_MAX_WRITE_BYTES = 286720
+APPLY_LOAD_TX_MAX_WRITE_BYTES = 132096
+
+APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES = 266240
+APPLY_LOAD_MAX_TX_SIZE_BYTES = 132096
+
+APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES = 16384
+APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 482
+
+# The following section contains various parameters for the generated load.
+
+# Number of ledgers to close for benchmark
+APPLY_LOAD_NUM_LEDGERS = 30
+
+# Generate that many simple Classic payment transactions in every benchmark ledger
+APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 10
+
+# Bucket list pre-generation
+
+# The benchmark will pre-generate ledger entries using the simplified ledger
+# close process; the generated ledgers won't be reflected in the meta or
+# history checkpoints.
+
+# Faster settings, more shallow BL (up to level 6)
+# Number of ledgers to close
+APPLY_LOAD_BL_SIMULATED_LEDGERS = 10000
+# Write a batch of entries every that many ledgers
+APPLY_LOAD_BL_WRITE_FREQUENCY = 1000
+# Write that many entries in every batch
+APPLY_LOAD_BL_BATCH_SIZE = 1000
+# Write that many entries in every batch in the 'last' ledgers
+APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+# Write entry batches in every ledger of this many last ledgers
+APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+
+# Number of events a transaction emits and the respective distribution weights.
+APPLY_LOAD_EVENT_COUNT = [5]
+APPLY_LOAD_EVENT_COUNT_DISTRIBUTION = [1]
+
+# Common apply load boilerplate
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
+# Diagnostic events should generally be disabled, but can be enabled for debug
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false
+# Set up plenty of genesis accounts - benchmark will fail if the number is
+# not sufficient. This should be at least 2x of the expected TPL, but it's cheap
+# enough to be set higher than that.
+GENESIS_TEST_ACCOUNT_COUNT = 40000
+
+# Minimal core config boilerplate
+
+# Note: core's apply-load command overrides the passphrase to "Apply Load"
+# regardless of this setting. It is set here so that the test harness (which
+# reads the passphrase from this file) matches what core actually uses.
+NETWORK_PASSPHRASE="Apply Load"
+
+UNSAFE_QUORUM=true
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+
+# Log to stdout instead of file (so we can parse the pre-benchmark checkpoint)
+LOG_FILE_PATH=""
+
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]
+
+# Local history configuration to use for catching up to the synthetic
+# ledger state generated before the apply load benchmark is executed.
+[HISTORY.local]
+get="cp -r history/{0} {1}"
+put="cp -r {0} history/{1}"
+mkdir="mkdir -p history/{0}"


### PR DESCRIPTION

Draft — for running CI integration tests only.