### PR TITLE
SPIKE: Protocol 28 (CAP-0084)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -170,3 +170,5 @@ require (
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/stellar/go-stellar-sdk => github.com/sisuresh/go v0.0.0-20260627053858-318bde14b520

--- a/go.mod
+++ b/go.mod
@@ -171,4 +171,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/stellar/go-stellar-sdk => github.com/sisuresh/go v0.0.0-20260627053858-318bde14b520
+replace github.com/stellar/go-stellar-sdk => github.com/sisuresh/go v0.0.0-20260701222026-51284c1e7418

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,8 @@ github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c h1:aqg5Vm5dwtvL+Yg
 github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c/go.mod h1:owqhoLW1qZoYLZzLnBw+QkPP9WZnjlSWihhxAJC1+/M=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sisuresh/go v0.0.0-20260627053858-318bde14b520 h1:Dvv5T93Qfj1VBmxqdvWf92xFv8BFg0TFFl4gMSR7QPI=
+github.com/sisuresh/go v0.0.0-20260627053858-318bde14b520/go.mod h1:IkcqcrE9UQi7n/1y+MxKB+7qzdjG1T2kGOD7Ss8dqjw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -429,8 +431,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.17.0 h1:I5txKw7MJasPL/BrfkbA0Jyo/oELqVmux4pR/UxOMfI=
 github.com/spf13/viper v1.17.0/go.mod h1:BmMMMLQXSbcHK6KAOiFLz0l5JHrU89OdIRHvsk0+yVI=
-github.com/stellar/go-stellar-sdk v0.6.1-0.20260616165505-26fec7c0e891 h1:Y/PtLm4L4ZHLDI1dXIflRjI5pY+m+KD7FUVFM07tV+E=
-github.com/stellar/go-stellar-sdk v0.6.1-0.20260616165505-26fec7c0e891/go.mod h1:IkcqcrE9UQi7n/1y+MxKB+7qzdjG1T2kGOD7Ss8dqjw=
 github.com/stellar/go-xdr v0.0.0-20260529210834-0bf8f4956364 h1:gOKrfuWdZ92LFlv0TAwgZ7OsWKeBsOMDlGLyFgduI1w=
 github.com/stellar/go-xdr v0.0.0-20260529210834-0bf8f4956364/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible h1:jMXXAcz6xTarGDQ4VtVbtERogcmDQw4RaE85Cr9CgoQ=

--- a/go.sum
+++ b/go.sum
@@ -413,8 +413,8 @@ github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c h1:aqg5Vm5dwtvL+Yg
 github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c/go.mod h1:owqhoLW1qZoYLZzLnBw+QkPP9WZnjlSWihhxAJC1+/M=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/sisuresh/go v0.0.0-20260627053858-318bde14b520 h1:Dvv5T93Qfj1VBmxqdvWf92xFv8BFg0TFFl4gMSR7QPI=
-github.com/sisuresh/go v0.0.0-20260627053858-318bde14b520/go.mod h1:IkcqcrE9UQi7n/1y+MxKB+7qzdjG1T2kGOD7Ss8dqjw=
+github.com/sisuresh/go v0.0.0-20260701222026-51284c1e7418 h1:t6BNG0+6IXmRxMXtREQQuH5yu85bsGE7GQbYbSAMwUE=
+github.com/sisuresh/go v0.0.0-20260701222026-51284c1e7418/go.mod h1:IkcqcrE9UQi7n/1y+MxKB+7qzdjG1T2kGOD7Ss8dqjw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/internal/ingest/contractevents/events.go
+++ b/internal/ingest/contractevents/events.go
@@ -317,10 +317,15 @@ func parseSacEventFromTxMetaV4(event *xdr.ContractEvent, networkPassphrase strin
 }
 
 // parseSacEventMap parses the ScMap data format used in V4 SAC events.
-// For SAC events, to_muxed_id represents the muxed account ID from
-// MuxedAddressObject - which is always a uint64. ScvBytes and ScvString are NOT
-// valid for SAC events (those are only used for classic transaction memo mappings
-// per CAP-67, which are processed through a different code path).
+// For SAC events, to_muxed_id is always a uint64. It carries either the muxed
+// account ID from a MuxedAddressObject (CAP-67) or, under CAP-0084, the muxed
+// contract ID from a MUXED_CONTRACT ScAddress. In both cases the SAC host
+// de-muxes the destination before emitting the event: the `to` topic holds the
+// base (account or contract) address and the mux id is surfaced separately as a
+// uint64, so the two are byte-identical in shape and indistinguishable from the
+// event alone. This holds for both transfer and mint. ScvBytes and ScvString are
+// NOT valid for SAC events (those are only used for classic transaction memo
+// mappings per CAP-67, which are processed through a different code path).
 func parseSacEventMap(mapData xdr.ScMap) (xdr.Int128Parts, xdr.Memo, error) {
 	var foundAmount, foundMuxedId bool
 	var amount xdr.Int128Parts
@@ -346,9 +351,11 @@ func parseSacEventMap(mapData xdr.ScMap) (xdr.Int128Parts, xdr.Memo, error) {
 
 		case "to_muxed_id":
 			foundMuxedId = true
-			// SAC events only emit uint64 for to_muxed_id (muxed account ID).
-			// ScvBytes/ScvString are NOT valid here - those are only for classic
-			// transaction memo mappings which use a different code path.
+			// SAC events only emit uint64 for to_muxed_id (muxed account ID under
+			// CAP-67, or muxed contract ID under CAP-0084 - both de-muxed by the
+			// host to a uint64). ScvBytes/ScvString are NOT valid here - those are
+			// only for classic transaction memo mappings which use a different
+			// code path.
 			switch entry.Val.Type {
 			case xdr.ScValTypeScvU64:
 				if val, ok := entry.Val.GetU64(); ok {

--- a/internal/ingest/contractevents/events_test.go
+++ b/internal/ingest/contractevents/events_test.go
@@ -21,6 +21,11 @@ var (
 	randomAccount    = keypair.MustRandom().Address()
 	zeroContractHash = xdr.Hash([32]byte{})
 	zeroContract     = strkey.MustEncode(strkey.VersionByteContract, zeroContractHash[:])
+	// muxedContractHash stands in for the base contract a CAP-0084
+	// MUXED_CONTRACT address de-muxes to. The host emits this base contract in
+	// the `to` topic and surfaces the mux id separately as a uint64.
+	muxedContractHash = xdr.Hash([32]byte{0xCA, 0xFE, 0xBA, 0xBE})
+	muxedContract     = strkey.MustEncode(strkey.VersionByteContract, muxedContractHash[:])
 )
 
 // Test fixture structure
@@ -240,6 +245,55 @@ func TestStellarAssetContractEventParsing(t *testing.T) {
 				To:              zeroContract,
 				Amount:          xdr.Int128Parts{Lo: 1000, Hi: 0},
 				DestinationMemo: xdr.MemoID(12345),
+			},
+		},
+		{
+			// CAP-0084: a transfer to a muxed contract destination. The host
+			// de-muxes the MUXED_CONTRACT address, emitting the base contract in
+			// the `to` topic and the mux id as a uint64 to_muxed_id - byte-identical
+			// in shape to the CAP-67 muxed-account case above, by design.
+			name:          "V4 transfer to muxed contract (CAP-0084)",
+			txMetaVersion: 4,
+			eventType:     EventTypeTransfer,
+			topics: []xdr.ScVal{
+				makeSymbol("transfer"),
+				makeAddress(randomAccount),
+				makeAddress(muxedContract),
+				makeAsset(randomAsset),
+			},
+			data:       makeV4MapData(big.NewInt(1000), xdr.MemoID(67890)),
+			asset:      randomAsset,
+			contractID: mustGetContractID(randomAsset),
+			expectedResult: &StellarAssetContractEvent{
+				Type:            EventTypeTransfer,
+				Asset:           randomAsset,
+				From:            randomAccount,
+				To:              muxedContract,
+				Amount:          xdr.Int128Parts{Lo: 1000, Hi: 0},
+				DestinationMemo: xdr.MemoID(67890),
+			},
+		},
+		{
+			// CAP-0084: a mint to a muxed contract destination. The mint path
+			// de-muxes the destination identically to transfer, so the muxed
+			// contract id surfaces as a uint64 to_muxed_id as well.
+			name:          "V4 mint to muxed contract (CAP-0084)",
+			txMetaVersion: 4,
+			eventType:     EventTypeMint,
+			topics: []xdr.ScVal{
+				makeSymbol("mint"),
+				makeAddress(muxedContract), // to (no admin in V4)
+				makeAsset(randomAsset),
+			},
+			data:       makeV4MapData(big.NewInt(2000), xdr.MemoID(67890)),
+			asset:      randomAsset,
+			contractID: mustGetContractID(randomAsset),
+			expectedResult: &StellarAssetContractEvent{
+				Type:            EventTypeMint,
+				Asset:           randomAsset,
+				To:              muxedContract,
+				Amount:          xdr.Int128Parts{Lo: 2000, Hi: 0},
+				DestinationMemo: xdr.MemoID(67890),
 			},
 		},
 		{


### PR DESCRIPTION
## Changes
- Re-pin `go-stellar-sdk` to the CAP-0084 regen (`sisuresh/go@318bde14`) which adds the `SC_ADDRESS_TYPE_MUXED_CONTRACT` arm.
- Document in `contractevents` that `to_muxed_id` carries the muxed **contract** id under CAP-0084 (host de-muxes the destination, byte-identical to CAP-67 muxed accounts) for both `transfer` and `mint`.
- Add two regression subtests (muxed-contract `transfer` + `mint`) to `TestStellarAssetContractEventParsing`.

**No functional contractevents change** (flag for review): the SAC host de-muxes the destination (`stellar_asset_contract/contract.rs`), emitting the base contract in the `to` topic and the mux id as a `uint64` `to_muxed_id`. Horizon's existing V4 path already decodes this. Verified byte-accurate against the core C++ test's `makeTransferEvent`/`makeMintOrBurnEvent` assertions (`InvokeHostFunctionTests.cpp:707-732`).

`MaxSupportedProtocolVersion` is already `28` on `protocol-next` (CAP-0083) — unchanged.

## Deferred
- **LCM ingestion fixture** — the CAP-0084 muxed-contract C++ test exists and is compiled in (`InvokeHostFunctionTests.cpp:695-733`, `CAP_0084_MUXED_CONTRACT=true` at core `e32fa4234`), but stellar-core at that commit has **no in-tree mechanism** to emit horizon's per-section framed `LedgerCloseMeta` fixtures: `grep -rn test-lcms` over core is empty, and the only LCM hook (`GENERATE_TEST_LEDGER_CLOSE_META` in `LedgerCloseMetaStreamTests.cpp`) writes core's own JSON references, not horizon's binary fixtures. Existing fixtures came from a separate generation patch (horizon `core-test-lcms` lineage) not ported to the CAP-0084 core. Coverage is instead provided by the two Go subtests above (a wiring guard only — `TestCoreLCMIngestion` asserts no ingestion error, no value validation).
- **CI matrix core image re-pin** — deferred until the `e32fa423…` core `-vnext` artifact publishes (latest vnext = CAP-0083). P28 RPC leg stays amber (no P28 RPC image; needs a protocol-28 `soroban-env-host`).

## Upstream
- go-stellar-sdk: stellar/go-stellar-sdk#5960
- stellar-core: sisuresh/stellar-core#18
- rs-soroban-env: stellar/rs-soroban-env#1696