### PR TITLE
Decompose Horizon integration tests into a callable workflow

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -6,119 +6,31 @@ on:
   pull_request:
 
 jobs:
-  integration:
-    name: Integration tests
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-        go: ["1.25", "1.26"]
-        pg: [14, 16]
-        protocol-version: [26, 27]
-    runs-on: ${{ matrix.os }}
-    services:
-      postgres:
-        image: postgres:${{ matrix.pg }}
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    env:
-      HORIZON_INTEGRATION_TESTS_ENABLED: true
-      HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_26_CORE_DOCKER_IMG: stellar/stellar-core:26.0.0-3089.8e43a2d3b.jammy
-      PROTOCOL_26_CORE_DEBIAN_PKG_VERSION: 26.0.0-3089.8e43a2d3b.jammy~buildtests
-      PROTOCOL_26_STELLAR_RPC_DOCKER_IMG: stellar/stellar-rpc:26.0.0
-      PROTOCOL_27_CORE_DOCKER_IMG: stellar/stellar-core:27.0.0-3288.7696c069d.jammy
-      PROTOCOL_27_CORE_DEBIAN_PKG_VERSION: 27.0.0-3288.7696c069d.jammy~buildtests
-      PROTOCOL_27_STELLAR_RPC_DOCKER_IMG: stellar/stellar-rpc:27.0.0-preview-190
-      PGHOST: localhost
-      PGPORT: 5432
-      PGUSER: postgres
-      PGPASSWORD: postgres
-      PGDATABASE: postgres
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # For pull requests, build and test the PR head not a merge of the PR with the destination.
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          # We need to full history for git-restore-mtime to know what modification dates to use.
-          # Otherwise, the Go test cache will fail (due to the modification time of fixtures changing).
-          fetch-depth: "0"
+  integration-p26-pkg:
+    name: Integration tests (P26)
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      protocol_version: '26'
+      core_deb_version: '26.0.0-3089.8e43a2d3b.jammy~buildtests'
+      core_docker_img: 'stellar/stellar-core:26.0.0-3089.8e43a2d3b.jammy'
+      stellar_rpc_docker_img: 'stellar/stellar-rpc:26.0.0'
 
-      # In order to debug the integration tests, run 'touch continue' once you connect to the ssh session
-      #
-      # - name: Setup upterm session
-      #  uses: lhotari/action-upterm@d23c2722bdab893785c9fbeae314cbf080645bd7
-      #  with:
-      #    ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-      #    limit-access-to-actor: true
-      #    ## limits ssh access and adds the ssh public keys of the listed GitHub users
-      #    limit-access-to-users: <yourGithubUser>
+  integration-p27-pkg:
+    name: Integration tests (P27)
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      protocol_version: '27'
+      core_deb_version: '27.0.0-3288.7696c069d.jammy~buildtests'
+      core_docker_img: 'stellar/stellar-core:27.0.0-3288.7696c069d.jammy'
+      stellar_rpc_docker_img: 'stellar/stellar-rpc:27.0.0-preview-190'
 
-      - uses: ./.github/actions/setup-go
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Pull and set Stellar Core image
-        shell: bash
-        run: |
-          docker pull "$PROTOCOL_${{ matrix.protocol-version }}_CORE_DOCKER_IMG"
-          echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="$PROTOCOL_${{ matrix.protocol-version }}_CORE_DOCKER_IMG" >> $GITHUB_ENV
-
-      - name: Pull and set Stellar RPC image
-        shell: bash
-        run: |
-          docker pull "$PROTOCOL_${{ matrix.protocol-version }}_STELLAR_RPC_DOCKER_IMG"
-          echo HORIZON_INTEGRATION_TESTS_STELLAR_RPC_DOCKER_IMG="$PROTOCOL_${{ matrix.protocol-version }}_STELLAR_RPC_DOCKER_IMG" >> $GITHUB_ENV
-
-      - name: Install core
-        run: |
-          sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
-          sudo bash -c 'echo "deb https://apt.stellar.org noble unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
-          # The 27.0.0 core build is only published for jammy, so add the jammy unstable repo as well,
-          # plus the LLVM-20 jammy repo for its libc++1/libc++abi1/libunwind runtime dependencies.
-          sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" >> /etc/apt/sources.list.d/SDF-unstable.list'
-          sudo wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
-          sudo bash -c 'echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm-jammy.list'
-          sudo apt-get update && sudo apt-get install -y stellar-core="$PROTOCOL_${{ matrix.protocol-version }}_CORE_DEBIAN_PKG_VERSION"
-          echo "Using stellar core version $(stellar-core version)"
-          echo 'HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_BIN=/usr/bin/stellar-core' >> $GITHUB_ENV
-
-      - name: Build Horizon reproducible build
-        run: |
-          go build -v -trimpath -buildvcs=false .
-          touch empty
-
-      - name: Calculate the source hash
-        id: calculate_source_hash
-        run: |
-          combined_hash=$(echo "horizon-hash-${{ hashFiles('./') }}-${{ hashFiles('./docker/**') }}-${{ hashFiles('./internal/**') }}-protocol-${{ matrix.protocol-version }}-${{ env.PROTOCOL_27_CORE_DOCKER_IMG }}-${{ env.PROTOCOL_27_STELLAR_RPC_DOCKER_IMG }}-${{ env.PROTOCOL_27_CORE_DEBIAN_PKG_VERSION }}-${{ env.PROTOCOL_26_CORE_DOCKER_IMG }}-${{ env.PREFIX }}" | sha256sum | cut -d ' ' -f 1)
-          echo "COMBINED_SOURCE_HASH=$combined_hash" >> "$GITHUB_ENV"
-
-      - name: Restore Horizon binary and integration tests source hash to cache
-        id: horizon_binary_tests_hash
-        uses: actions/cache/restore@v4
-        with:
-          path: ./empty
-          lookup-only: true
-          key: ${{ env.COMBINED_SOURCE_HASH }}
-
-      - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
-        run: go test -race -timeout 75m -v ./internal/integration/...
-
-      - name: Save Horizon binary and integration tests source hash to cache
-        if: ${{ success() && steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ./empty
-          key: ${{ env.COMBINED_SOURCE_HASH }}
+  # integration-p27-src:
+  #   name: Integration tests (P27, core from source)
+  #   uses: ./.github/workflows/integration-tests.yml
+  #   with:
+  #     protocol_version: '27'
+  #     core_git_ref: 'master'
+  #     stellar_rpc_docker_img: 'stellar/stellar-rpc:27.0.0-preview-190'
 
   verify-range:
     name: Test (and push) verify-range image

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -14,6 +14,7 @@ jobs:
       core_deb_version: '27.1.0-3365.3589a696b.jammy~buildtests'
       core_docker_img: 'stellar/stellar-core:27.1.0-3365.3589a696b.jammy'
       stellar_rpc_docker_img: 'stellar/stellar-rpc:27.1.0'
+      full_matrix: true
 
   integration-p27-pkg:
     name: Integration tests (P27)
@@ -23,6 +24,7 @@ jobs:
       core_deb_version: '27.1.0-3365.3589a696b.jammy~buildtests'
       core_docker_img: 'stellar/stellar-core:27.1.0-3365.3589a696b.jammy'
       stellar_rpc_docker_img: 'stellar/stellar-rpc:27.1.0'
+      full_matrix: true
 
   # integration-p27-src:
   #   name: Integration tests (P27, core from source)

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -13,7 +13,7 @@ jobs:
       protocol_version: '26'
       core_deb_version: '27.1.0-3365.3589a696b.jammy~buildtests'
       core_docker_img: 'stellar/stellar-core:27.1.0-3365.3589a696b.jammy'
-      stellar_rpc_docker_img: 'stellar/stellar-rpc:26.0.0'
+      stellar_rpc_docker_img: 'stellar/stellar-rpc:27.1.0'
 
   integration-p27-pkg:
     name: Integration tests (P27)
@@ -22,7 +22,7 @@ jobs:
       protocol_version: '27'
       core_deb_version: '27.1.0-3365.3589a696b.jammy~buildtests'
       core_docker_img: 'stellar/stellar-core:27.1.0-3365.3589a696b.jammy'
-      stellar_rpc_docker_img: 'stellar/stellar-rpc:27.0.0-preview-190'
+      stellar_rpc_docker_img: 'stellar/stellar-rpc:27.1.0'
 
   # integration-p27-src:
   #   name: Integration tests (P27, core from source)

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -11,8 +11,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '26'
-      core_deb_version: '26.0.0-3089.8e43a2d3b.jammy~buildtests'
-      core_docker_img: 'stellar/stellar-core:26.0.0-3089.8e43a2d3b.jammy'
+      core_deb_version: '27.1.0-3365.3589a696b.jammy~buildtests'
+      core_docker_img: 'stellar/stellar-core:27.1.0-3365.3589a696b.jammy'
       stellar_rpc_docker_img: 'stellar/stellar-rpc:26.0.0'
 
   integration-p27-pkg:
@@ -20,8 +20,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '27.0.0-3288.7696c069d.jammy~buildtests'
-      core_docker_img: 'stellar/stellar-core:27.0.0-3288.7696c069d.jammy'
+      core_deb_version: '27.1.0-3365.3589a696b.jammy~buildtests'
+      core_docker_img: 'stellar/stellar-core:27.1.0-3365.3589a696b.jammy'
       stellar_rpc_docker_img: 'stellar/stellar-rpc:27.0.0-preview-190'
 
   # integration-p27-src:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GO_VERSION: 1.25.0
-      STELLAR_CORE_VERSION: 27.0.0-3288.7696c069d.noble
+      STELLAR_CORE_VERSION: 27.1.0-3365.3589a696b.noble
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -123,7 +123,7 @@ jobs:
           # The binary is built on ubuntu:noble with clang-20/libc++, so we need the
           # matching libc++ runtime libraries on the ubuntu-24.04 runner.
           sudo wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
-          sudo bash -c 'echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list'
+          sudo bash -c 'echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list'
           sudo apt-get update
           sudo apt-get install -y libc++abi1-20 libc++1-20
 
@@ -151,7 +151,7 @@ jobs:
           # plus the LLVM-20 jammy repo for its libc++1/libc++abi1/libunwind runtime dependencies.
           sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" >> /etc/apt/sources.list.d/SDF-unstable.list'
           sudo wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
-          sudo bash -c 'echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm-jammy.list'
+          sudo bash -c 'echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm-jammy.list'
           sudo apt-get update && sudo apt-get install -y stellar-core="$CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,191 @@
+name: Horizon Integration Tests
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      horizon_git_ref:
+        description: 'Git ref (branch, tag, or SHA) of stellar/stellar-horizon to run tests on. Required when running from separate repo, branch tip otherwise.'
+        required: false
+        type: string
+      protocol_version:
+        description: 'Protocol version to test (e.g. 27)'
+        required: true
+        type: string
+      core_deb_version:
+        description: 'Stellar Core debian package version (e.g. 27.0.0-3288.7696c069d.jammy~buildtests). Mutually exclusive with core_git_ref.'
+        required: false
+        type: string
+      core_docker_img:
+        description: 'Full docker image reference for Stellar Core (e.g. stellar/stellar-core:27.0.0-3288.7696c069d.jammy). Mutually exclusive with core_git_ref.'
+        required: false
+        type: string
+      core_git_ref:
+        description: 'Git ref (branch, tag, or SHA) of stellar/stellar-core to build from source. Mutually exclusive with core_deb_version/core_docker_img.'
+        required: false
+        type: string
+      stellar_rpc_docker_img:
+        description: 'Full docker image reference for Stellar RPC (e.g. stellar/stellar-rpc:27.0.0)'
+        required: true
+        type: string
+
+jobs:
+  integration:
+    name: Integration tests
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        go: ["1.25", "1.26"]
+        pg: [14, 16]
+    runs-on: ${{ matrix.os }}
+    services:
+      postgres:
+        image: postgres:${{ matrix.pg }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      HORIZON_INTEGRATION_TESTS_ENABLED: true
+      HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ inputs.protocol_version }}
+      HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
+      CORE_DEBIAN_PKG_VERSION: ${{ inputs.core_deb_version }}
+      CORE_DOCKER_IMG: ${{ inputs.core_docker_img }}
+      CORE_GIT_REF: ${{ inputs.core_git_ref || '' }}
+      HORIZON_GIT_REF: ${{ inputs.horizon_git_ref || '' }}
+      STELLAR_RPC_DOCKER_IMG: ${{ inputs.stellar_rpc_docker_img }}
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: postgres
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Because this is a callable workflow, we need to explicitly specify the repo, since otherwise
+          # it will check out the caller's repo.
+          repository: stellar/stellar-horizon
+          # For pull requests, build and test the PR head not a merge of the PR with the destination.
+          ref: ${{ env.HORIZON_GIT_REF || github.event.pull_request.head.sha || github.ref }}
+          # We need to full history for git-restore-mtime to know what modification dates to use.
+          # Otherwise, the Go test cache will fail (due to the modification time of fixtures changing).
+          fetch-depth: "0"
+
+      # In order to debug the integration tests, run 'touch continue' once you connect to the ssh session
+      #
+      # - name: Setup upterm session
+      #  uses: lhotari/action-upterm@d23c2722bdab893785c9fbeae314cbf080645bd7
+      #  with:
+      #    ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+      #    limit-access-to-actor: true
+      #    ## limits ssh access and adds the ssh public keys of the listed GitHub users
+      #    limit-access-to-users: <yourGithubUser>
+
+      - uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{ matrix.go }}
+
+      # --- Build stellar-core from source when core_git_ref is provided ---
+      - name: Build Stellar Core from source
+        if: env.CORE_GIT_REF != ''
+        run: |
+          echo "Building stellar-core from source at ref: ${CORE_GIT_REF}"
+          git clone --depth 50 https://github.com/stellar/stellar-core.git /tmp/stellar-core-src
+          cd /tmp/stellar-core-src
+          git fetch origin "${CORE_GIT_REF}" && git checkout FETCH_HEAD || git checkout "${CORE_GIT_REF}"
+          git submodule update --init --recursive
+
+          # Build using stellar-core's own Dockerfile.testing
+          docker build --pull --platform linux/amd64 \
+            -f docker/Dockerfile.testing \
+            -t stellar-core:local-build .
+
+          # Extract the binary from the image for captive core use
+          docker create --name stellar-core-extract stellar-core:local-build
+          sudo docker cp stellar-core-extract:/usr/local/bin/stellar-core /usr/bin/stellar-core
+          docker rm stellar-core-extract
+
+          # Install runtime dependencies needed by the source-built binary on the host.
+          # The binary is built on ubuntu:noble with clang-20/libc++, so we need the
+          # matching libc++ runtime libraries on the ubuntu-24.04 runner.
+          sudo wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
+          sudo bash -c 'echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list'
+          sudo apt-get update
+          sudo apt-get install -y libc++abi1-20 libc++1-20
+
+          echo "Built stellar-core from source:"
+          stellar-core version
+
+      - name: Set Stellar Core docker image (from source build)
+        if: env.CORE_GIT_REF != ''
+        run: |
+          echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="stellar-core:local-build" >> $GITHUB_ENV
+
+      # --- Use pre-built debian package and docker image when core_git_ref is NOT provided ---
+      - name: Pull and set Stellar Core image
+        if: env.CORE_GIT_REF == ''
+        run: |
+          docker pull "$CORE_DOCKER_IMG"
+          echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="$CORE_DOCKER_IMG" >> $GITHUB_ENV
+
+      - name: Install Captive Core from debian package
+        if: env.CORE_GIT_REF == ''
+        run: |
+          sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
+          sudo bash -c 'echo "deb https://apt.stellar.org noble unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
+          # The 27.0.0 core build is only published for jammy, so add the jammy unstable repo as well,
+          # plus the LLVM-20 jammy repo for its libc++1/libc++abi1/libunwind runtime dependencies.
+          sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" >> /etc/apt/sources.list.d/SDF-unstable.list'
+          sudo wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
+          sudo bash -c 'echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm-jammy.list'
+          sudo apt-get update && sudo apt-get install -y stellar-core="$CORE_DEBIAN_PKG_VERSION"
+          echo "Using stellar core version $(stellar-core version)"
+
+      - name: Pull and set Stellar RPC image
+        run: |
+          docker pull "$STELLAR_RPC_DOCKER_IMG"
+          echo HORIZON_INTEGRATION_TESTS_STELLAR_RPC_DOCKER_IMG="$STELLAR_RPC_DOCKER_IMG" >> $GITHUB_ENV
+
+      - name: Build Horizon reproducible build
+        run: |
+          go build -v -trimpath -buildvcs=false .
+          touch empty
+
+      # The test-skipping cache only makes sense when core comes from pinned artifacts.
+      # A core_git_ref may be a moving branch, so from-source builds always run the tests.
+      - name: Calculate the source hash
+        if: env.CORE_GIT_REF == ''
+        id: calculate_source_hash
+        run: |
+          combined_hash=$(echo "horizon-hash-${{ hashFiles('./') }}-${{ hashFiles('./docker/**') }}-${{ hashFiles('./internal/**') }}-protocol-${{ inputs.protocol_version }}-${{ env.CORE_DOCKER_IMG }}-${{ env.STELLAR_RPC_DOCKER_IMG }}-${{ env.CORE_DEBIAN_PKG_VERSION }}" | sha256sum | cut -d ' ' -f 1)
+          echo "COMBINED_SOURCE_HASH=$combined_hash" >> "$GITHUB_ENV"
+
+      - name: Restore Horizon binary and integration tests source hash to cache
+        if: env.CORE_GIT_REF == ''
+        id: horizon_binary_tests_hash
+        uses: actions/cache/restore@v4
+        with:
+          path: ./empty
+          lookup-only: true
+          key: ${{ env.COMBINED_SOURCE_HASH }}
+
+      - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
+        name: Run Horizon Integration Tests
+        run: go test -race -timeout 75m -v ./internal/integration/...
+
+      - name: Save Horizon binary and integration tests source hash to cache
+        if: ${{ success() && env.CORE_GIT_REF == '' && steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./empty
+          key: ${{ env.COMBINED_SOURCE_HASH }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -149,7 +149,14 @@ jobs:
           # `docker pull` the core image, which fails for a local-only image.
           # Serve the locally built image from a local registry so pulls resolve.
           docker run -d -p 5000:5000 --name local-registry registry:2
-          docker tag stellar-core:local-build localhost:5000/stellar-core:local-build
+          # Dockerfile.testing sets no ENTRYPOINT (just `CMD stellar-core`), but
+          # the test suite also invokes the image as `docker run <img> <subcommand>`,
+          # which expects the entrypoint to be the stellar-core binary like in the
+          # release image. Overlay one before publishing.
+          docker build -t localhost:5000/stellar-core:local-build - <<'EOF'
+          FROM stellar-core:local-build
+          ENTRYPOINT ["/usr/local/bin/stellar-core"]
+          EOF
           docker push localhost:5000/stellar-core:local-build
           echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="localhost:5000/stellar-core:local-build" >> $GITHUB_ENV
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -204,7 +204,11 @@ jobs:
         if: env.CORE_GIT_REF == ''
         id: calculate_source_hash
         run: |
-          combined_hash=$(echo "horizon-hash-${{ hashFiles('./') }}-${{ hashFiles('./docker/**') }}-${{ hashFiles('./internal/**') }}-protocol-${{ inputs.protocol_version }}-${{ env.CORE_DOCKER_IMG }}-${{ env.STELLAR_RPC_DOCKER_IMG }}-${{ env.CORE_DEBIAN_PKG_VERSION }}" | sha256sum | cut -d ' ' -f 1)
+          # The prefix uniquely identifies the job instance (what setup-go's PREFIX
+          # captured: workflow, job, OS, go version), plus the full matrix combination
+          # so that a pass on one go/pg combination never skips tests for another.
+          prefix="${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-go${{ matrix.go }}-matrix(${{ join(matrix.*, '|') }})"
+          combined_hash=$(echo "horizon-hash-${{ hashFiles('./') }}-${{ hashFiles('./docker/**') }}-${{ hashFiles('./internal/**') }}-protocol-${{ inputs.protocol_version }}-${{ env.CORE_DOCKER_IMG }}-${{ env.STELLAR_RPC_DOCKER_IMG }}-${{ env.CORE_DEBIAN_PKG_VERSION }}-${prefix}" | sha256sum | cut -d ' ' -f 1)
           echo "COMBINED_SOURCE_HASH=$combined_hash" >> "$GITHUB_ENV"
 
       - name: Restore Horizon binary and integration tests source hash to cache

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,6 +72,17 @@ jobs:
       PGPASSWORD: postgres
       PGDATABASE: postgres
     steps:
+      - name: Validate Stellar Core inputs
+        run: |
+          if [[ -n "$CORE_GIT_REF" && ( -n "$CORE_DEBIAN_PKG_VERSION" || -n "$CORE_DOCKER_IMG" ) ]]; then
+            echo "::error::core_git_ref is mutually exclusive with core_deb_version/core_docker_img"
+            exit 1
+          fi
+          if [[ -z "$CORE_GIT_REF" && ( -z "$CORE_DEBIAN_PKG_VERSION" || -z "$CORE_DOCKER_IMG" ) ]]; then
+            echo "::error::provide either core_git_ref, or both core_deb_version and core_docker_img"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           # Because this is a callable workflow, we need to explicitly specify the repo, since otherwise

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -203,12 +203,19 @@ jobs:
       - name: Calculate the source hash
         if: env.CORE_GIT_REF == ''
         id: calculate_source_hash
+        # Inputs are expanded as shell variables, not ${{ }} expressions, so that
+        # caller-provided values can't inject into the script. hashFiles() has no
+        # shell-variable equivalent, but its output is a fixed-format hash.
+        env:
+          GO_VERSION: ${{ matrix.go }}
+          MATRIX_COMBO: ${{ join(matrix.*, '|') }}
+          PROTOCOL_VERSION: ${{ inputs.protocol_version }}
         run: |
           # The prefix uniquely identifies the job instance (what setup-go's PREFIX
           # captured: workflow, job, OS, go version), plus the full matrix combination
           # so that a pass on one go/pg combination never skips tests for another.
-          prefix="${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-go${{ matrix.go }}-matrix(${{ join(matrix.*, '|') }})"
-          combined_hash=$(echo "horizon-hash-${{ hashFiles('./') }}-${{ hashFiles('./docker/**') }}-${{ hashFiles('./internal/**') }}-protocol-${{ inputs.protocol_version }}-${{ env.CORE_DOCKER_IMG }}-${{ env.STELLAR_RPC_DOCKER_IMG }}-${{ env.CORE_DEBIAN_PKG_VERSION }}-${prefix}" | sha256sum | cut -d ' ' -f 1)
+          prefix="${GITHUB_WORKFLOW}-${GITHUB_JOB}-${RUNNER_OS}-go${GO_VERSION}-matrix(${MATRIX_COMBO})"
+          combined_hash=$(echo "horizon-hash-${{ hashFiles('./') }}-${{ hashFiles('./docker/**') }}-${{ hashFiles('./internal/**') }}-protocol-${PROTOCOL_VERSION}-${CORE_DOCKER_IMG}-${STELLAR_RPC_DOCKER_IMG}-${CORE_DEBIAN_PKG_VERSION}-${prefix}" | sha256sum | cut -d ' ' -f 1)
           echo "COMBINED_SOURCE_HASH=$combined_hash" >> "$GITHUB_ENV"
 
       - name: Restore Horizon binary and integration tests source hash to cache

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,15 +31,17 @@ on:
         description: 'Full docker image reference for Stellar RPC (e.g. stellar/stellar-rpc:27.0.0)'
         required: true
         type: string
+      full_matrix:
+        description: 'Run the full go/postgres version matrix. Defaults to false: a single job on the latest go and postgres, which is what external callers (e.g. stellar-core CI) want.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   integration:
     name: Integration tests
     strategy:
-      matrix:
-        os: [ubuntu-24.04]
-        go: ["1.25", "1.26"]
-        pg: [14, 16]
+      matrix: ${{ inputs.full_matrix && fromJSON('{"os":["ubuntu-24.04"],"go":["1.25","1.26"],"pg":[14,16]}') || fromJSON('{"os":["ubuntu-24.04"],"go":["1.26"],"pg":[16]}') }}
     runs-on: ${{ matrix.os }}
     services:
       postgres:
@@ -76,7 +78,9 @@ jobs:
           # it will check out the caller's repo.
           repository: stellar/stellar-horizon
           # For pull requests, build and test the PR head not a merge of the PR with the destination.
-          ref: ${{ env.HORIZON_GIT_REF || github.event.pull_request.head.sha || github.ref }}
+          # When invoked from another repo (e.g. stellar/stellar-core) the caller's PR head SHA / ref
+          # doesn't exist in stellar-horizon, so fall back to main unless horizon_git_ref is provided.
+          ref: ${{ env.HORIZON_GIT_REF || (github.repository == 'stellar/stellar-horizon' && (github.event.pull_request.head.sha || github.ref)) || 'refs/heads/main' }}
           # We need to full history for git-restore-mtime to know what modification dates to use.
           # Otherwise, the Go test cache will fail (due to the modification time of fixtures changing).
           fetch-depth: "0"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -164,12 +164,20 @@ jobs:
       - name: Pull and set Stellar Core image
         if: env.CORE_GIT_REF == ''
         run: |
+          if [[ -z "${CORE_DOCKER_IMG}" ]]; then
+            echo "core_docker_img input is required when core_git_ref is not set" >&2
+            exit 1
+          fi
           docker pull "$CORE_DOCKER_IMG"
           echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="$CORE_DOCKER_IMG" >> $GITHUB_ENV
 
       - name: Install Captive Core from debian package
         if: env.CORE_GIT_REF == ''
         run: |
+          if [[ -z "${CORE_DEBIAN_PKG_VERSION}" ]]; then
+            echo "core_deb_version input is required when core_git_ref is not set" >&2
+            exit 1
+          fi
           sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
           sudo bash -c 'echo "deb https://apt.stellar.org noble unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
           # The 27.0.0 core build is only published for jammy, so add the jammy unstable repo as well,

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -144,7 +144,14 @@ jobs:
       - name: Set Stellar Core docker image (from source build)
         if: env.CORE_GIT_REF != ''
         run: |
-          echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="stellar-core:local-build" >> $GITHUB_ENV
+          # Parts of the test suite (e.g. soroban config upgrades via
+          # go-stellar-sdk's GenSorobanConfigUpgradeTxAndKey) unconditionally
+          # `docker pull` the core image, which fails for a local-only image.
+          # Serve the locally built image from a local registry so pulls resolve.
+          docker run -d -p 5000:5000 --name local-registry registry:2
+          docker tag stellar-core:local-build localhost:5000/stellar-core:local-build
+          docker push localhost:5000/stellar-core:local-build
+          echo HORIZON_INTEGRATION_TESTS_DOCKER_IMG="localhost:5000/stellar-core:local-build" >> $GITHUB_ENV
 
       # --- Use pre-built debian package and docker image when core_git_ref is NOT provided ---
       - name: Pull and set Stellar Core image


### PR DESCRIPTION
Extracts the `integration-test` job into `.github/workflows/integration-tests.yml`, mirroring RPC, so other repos (namely stellar-core CI) can invoke it by building core from source via `core_git_ref` and `Dockerfile.testing`.

- Callers provide either `core_git_ref` or `core_deb_version` + `core_docker_img` (validated up front)
- `full_matrix` input: Horizon CI runs the full go+pg matrix; external callers get a single latest-versions job by default
- Source-built core images are served from a local registry with a stellar-core `ENTRYPOINT` overlay, since the test suite pulls and runs the image with subcommands
