### PR TITLE
Update stellar-core pubnet config quorums

### DIFF
--- a/docker/stellar-core-pubnet.cfg
+++ b/docker/stellar-core-pubnet.cfg
@@ -13,11 +13,23 @@ CATCHUP_RECENT=100
 get="cp /opt/stellar/history-cache/{0} {1}"
 
 [[HOME_DOMAINS]]
+HOME_DOMAIN="lobstr.co"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
 HOME_DOMAIN="publicnode.org"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="lobstr.co"
+HOME_DOMAIN="stellar.blockdaemon.com"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="stellar.creit.tech"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="stellar.withobsrvr.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
@@ -25,41 +37,8 @@ HOME_DOMAIN="www.franklintempleton.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="satoshipay.io"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="whalestack.com"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
 HOME_DOMAIN="www.stellar.org"
 QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="stellar.blockdaemon.com"
-QUALITY="HIGH"
-
-[[VALIDATORS]]
-NAME="Boötes"
-PUBLIC_KEY="GCVJ4Z6TI6Z2SOGENSPXDQ2U4RKH3CNQKYUHNSSPYFPNWTLGS6EBH7I2"
-ADDRESS="bootes.publicnode.org:11625"
-HISTORY="curl -sf https://bootes-history.publicnode.org/{0} -o {1}"
-HOME_DOMAIN="publicnode.org"
-
-[[VALIDATORS]]
-NAME="Lyra by BP Ventures"
-PUBLIC_KEY="GCIXVKNFPKWVMKJKVK2V4NK7D4TC6W3BUMXSIJ365QUAXWBRPPJXIR2Z"
-ADDRESS="lyra.publicnode.org:11625"
-HISTORY="curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
-HOME_DOMAIN="publicnode.org"
-
-[[VALIDATORS]]
-NAME="Hercules by OG Technologies"
-PUBLIC_KEY="GBLJNN3AVZZPG2FYAYTYQKECNWTQYYUUY2KVFN2OUKZKBULXIXBZ4FCT"
-ADDRESS="hercules.publicnode.org:11625"
-HISTORY="curl -sf https://hercules-history.publicnode.org/{0} -o {1}"
-HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
 NAME="LOBSTR 1 (Europe)"
@@ -83,94 +62,31 @@ HISTORY="curl -sf https://archive.v5.stellar.lobstr.co/{0} -o {1}"
 HOME_DOMAIN="lobstr.co"
 
 [[VALIDATORS]]
-NAME="FT SCV 2"
-PUBLIC_KEY="GCMSM2VFZGRPTZKPH5OABHGH4F3AVS6XTNJXDGCZ3MKCOSUBH3FL6DOB"
-ADDRESS="stellar2.franklintempleton.com:11625"
-HISTORY="curl -sf https://stellar-history-usc.franklintempleton.com/azuscshf401/{0} -o {1}"
-HOME_DOMAIN="www.franklintempleton.com"
+NAME="Boötes"
+PUBLIC_KEY="GCVJ4Z6TI6Z2SOGENSPXDQ2U4RKH3CNQKYUHNSSPYFPNWTLGS6EBH7I2"
+ADDRESS="bootes.publicnode.org:11625"
+HISTORY="curl -sf https://bootes-history.publicnode.org/{0} -o {1}"
+HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="FT SCV 3"
-PUBLIC_KEY="GA7DV63PBUUWNUFAF4GAZVXU2OZMYRATDLKTC7VTCG7AU4XUPN5VRX4A"
-ADDRESS="stellar3.franklintempleton.com:11625"
-HISTORY="curl -sf https://stellar-history-ins.franklintempleton.com/azinsshf401/{0} -o {1}"
-HOME_DOMAIN="www.franklintempleton.com"
+NAME="Hercules"
+PUBLIC_KEY="GBLJNN3AVZZPG2FYAYTYQKECNWTQYYUUY2KVFN2OUKZKBULXIXBZ4FCT"
+ADDRESS="hercules.publicnode.org:11625"
+HISTORY="curl -sf https://hercules-history.publicnode.org/{0} -o {1}"
+HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="FT SCV 1"
-PUBLIC_KEY="GARYGQ5F2IJEBCZJCBNPWNWVDOFK7IBOHLJKKSG2TMHDQKEEC6P4PE4V"
-ADDRESS="stellar1.franklintempleton.com:11625"
-HISTORY="curl -sf https://stellar-history-usw.franklintempleton.com/azuswshf401/{0} -o {1}"
-HOME_DOMAIN="www.franklintempleton.com"
+NAME="Lyra"
+PUBLIC_KEY="GCIXVKNFPKWVMKJKVK2V4NK7D4TC6W3BUMXSIJ365QUAXWBRPPJXIR2Z"
+ADDRESS="lyra.publicnode.org:11625"
+HISTORY="curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
+HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="SatoshiPay Frankfurt"
-PUBLIC_KEY="GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS="stellar-de-fra.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay.io"
-
-[[VALIDATORS]]
-NAME="SatoshiPay Singapore"
-PUBLIC_KEY="GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS="stellar-sg-sin.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay.io"
-
-[[VALIDATORS]]
-NAME="SatoshiPay Iowa"
-PUBLIC_KEY="GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS="stellar-us-iowa.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay.io"
-
-[[VALIDATORS]]
-NAME="Whalestack (Germany)"
-PUBLIC_KEY="GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN"
-ADDRESS="germany.stellar.whalestack.com:11625"
-HISTORY="curl -sf https://germany.stellar.whalestack.com/history/{0} -o {1}"
-HOME_DOMAIN="whalestack.com"
-
-[[VALIDATORS]]
-NAME="Whalestack (Hong Kong)"
-PUBLIC_KEY="GAZ437J46SCFPZEDLVGDMKZPLFO77XJ4QVAURSJVRZK2T5S7XUFHXI2Z"
-ADDRESS="hongkong.stellar.whalestack.com:11625"
-HISTORY="curl -sf https://hongkong.stellar.whalestack.com/history/{0} -o {1}"
-HOME_DOMAIN="whalestack.com"
-
-[[VALIDATORS]]
-NAME="Whalestack (Finland)"
-PUBLIC_KEY="GADLA6BJK6VK33EM2IDQM37L5KGVCY5MSHSHVJA4SCNGNUIEOTCR6J5T"
-ADDRESS="finland.stellar.whalestack.com:11625"
-HISTORY="curl -sf https://finland.stellar.whalestack.com/history/{0} -o {1}"
-HOME_DOMAIN="whalestack.com"
-
-[[VALIDATORS]]
-NAME="SDF 2"
-PUBLIC_KEY="GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
-ADDRESS="core-live-b.stellar.org:11625"
-HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
-HOME_DOMAIN="www.stellar.org"
-
-[[VALIDATORS]]
-NAME="SDF 1"
-PUBLIC_KEY="GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
-ADDRESS="core-live-a.stellar.org:11625"
-HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
-HOME_DOMAIN="www.stellar.org"
-
-[[VALIDATORS]]
-NAME="SDF 3"
-PUBLIC_KEY="GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
-ADDRESS="core-live-c.stellar.org:11625"
-HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
-HOME_DOMAIN="www.stellar.org"
-
-[[VALIDATORS]]
-NAME="Blockdaemon Validator 3"
-PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
-ADDRESS="stellar-full-validator3.bdnodes.net:11625"
-HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
+NAME="Blockdaemon Validator 1"
+PUBLIC_KEY="GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
+ADDRESS="stellar-full-validator1.bdnodes.net:11625"
+HISTORY="curl -sf https://stellar-full-history1.bdnodes.net/{0} -o {1}"
 HOME_DOMAIN="stellar.blockdaemon.com"
 
 [[VALIDATORS]]
@@ -181,8 +97,92 @@ HISTORY="curl -sf https://stellar-full-history2.bdnodes.net/{0} -o {1}"
 HOME_DOMAIN="stellar.blockdaemon.com"
 
 [[VALIDATORS]]
-NAME="Blockdaemon Validator 1"
-PUBLIC_KEY="GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
-ADDRESS="stellar-full-validator1.bdnodes.net:11625"
-HISTORY="curl -sf https://stellar-full-history1.bdnodes.net/{0} -o {1}"
+NAME="Blockdaemon Validator 3"
+PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
+ADDRESS="stellar-full-validator3.bdnodes.net:11625"
+HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
 HOME_DOMAIN="stellar.blockdaemon.com"
+
+[[VALIDATORS]]
+NAME="Alpha Node Validator"
+PUBLIC_KEY="GBPLJDBFZO2H7QQH7YFCH3HFT6EMC42Z2DNJ2QFROCKETAPY54V4DCZD"
+ADDRESS="alpha.validator.stellar.creit.tech:11625"
+HISTORY="curl -sf https://alpha-history.validator.stellar.creit.tech/{0} -o {1}"
+HOME_DOMAIN="stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME="Beta Node Validator"
+PUBLIC_KEY="GDDANSYOYSY5EPSFHBRPCLX6XMHPPLIMHVIDXG6IPQLVVLRI2BN4HMH3"
+ADDRESS="beta.validator.stellar.creit.tech:11625"
+HISTORY="curl -sf https://beta-history.validator.stellar.creit.tech/{0} -o {1}"
+HOME_DOMAIN="stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME="Gamma Node Validator"
+PUBLIC_KEY="GBF7QOLFPTHUEDUPTT4ZTULDTA3QXDIO75JHKJN2IYD7YGQLYUTR75BT"
+ADDRESS="gamma.validator.stellar.creit.tech:11625"
+HISTORY="curl -sf https://gamma-history.validator.stellar.creit.tech/{0} -o {1}"
+HOME_DOMAIN="stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME="OBSRVR Validator 1"
+PUBLIC_KEY="GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS="core-live-1.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME="OBSRVR Validator 2"
+PUBLIC_KEY="GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS="core-live-2.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME="OBSRVR Validator 3"
+PUBLIC_KEY="GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS="core-live-3.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME="FT SCV 1"
+PUBLIC_KEY="GARYGQ5F2IJEBCZJCBNPWNWVDOFK7IBOHLJKKSG2TMHDQKEEC6P4PE4V"
+ADDRESS="stellar1.franklintempleton.com:11625"
+HISTORY="curl -sf https://stellar-history1.franklintempleton.com/history1/{0} -o {1}"
+HOME_DOMAIN="www.franklintempleton.com"
+
+[[VALIDATORS]]
+NAME="FT SCV 2"
+PUBLIC_KEY="GCMSM2VFZGRPTZKPH5OABHGH4F3AVS6XTNJXDGCZ3MKCOSUBH3FL6DOB"
+ADDRESS="stellar2.franklintempleton.com:11625"
+HISTORY="curl -sf https://stellar-history2.franklintempleton.com/history2/{0} -o {1}"
+HOME_DOMAIN="www.franklintempleton.com"
+
+[[VALIDATORS]]
+NAME="FT SCV 3"
+PUBLIC_KEY="GA7DV63PBUUWNUFAF4GAZVXU2OZMYRATDLKTC7VTCG7AU4XUPN5VRX4A"
+ADDRESS="stellar3.franklintempleton.com:11625"
+HISTORY="curl -sf https://stellar-history3.franklintempleton.com/history3/{0} -o {1}"
+HOME_DOMAIN="www.franklintempleton.com"
+
+[[VALIDATORS]]
+NAME="SDF 1"
+PUBLIC_KEY="GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
+ADDRESS="core-live-a.stellar.org:11625"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
+HOME_DOMAIN="www.stellar.org"
+
+[[VALIDATORS]]
+NAME="SDF 2"
+PUBLIC_KEY="GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
+ADDRESS="core-live-b.stellar.org:11625"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+HOME_DOMAIN="www.stellar.org"
+
+[[VALIDATORS]]
+NAME="SDF 3"
+PUBLIC_KEY="GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
+ADDRESS="core-live-c.stellar.org:11625"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
+HOME_DOMAIN="www.stellar.org"

--- a/internal/testdata/captive-core-pubnet.cfg
+++ b/internal/testdata/captive-core-pubnet.cfg
@@ -6,19 +6,15 @@ HTTP_PORT=11626
 PEER_PORT=11725
 
 [[HOME_DOMAINS]]
+HOME_DOMAIN="lobstr.co"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
 HOME_DOMAIN="publicnode.org"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="lobstr"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="www.franklintempleton.com"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="satoshipay"
+HOME_DOMAIN="stellar.blockdaemon.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
@@ -26,156 +22,160 @@ HOME_DOMAIN="stellar.creit.tech"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="sdf"
+HOME_DOMAIN="stellar.withobsrvr.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="blockdaemon"
+HOME_DOMAIN="www.franklintempleton.com"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="www.stellar.org"
 QUALITY="HIGH"
 
 [[VALIDATORS]]
-NAME="bootes"
+NAME="LOBSTR 1 (Europe)"
+PUBLIC_KEY="GCFONE23AB7Y6C5YZOMKUKGETPIAJA4QOYLS5VNS4JHBGKRZCPYHDLW7"
+ADDRESS="v1.stellar.lobstr.co:11625"
+HISTORY="curl -sf https://archive.v1.stellar.lobstr.co/{0} -o {1}"
+HOME_DOMAIN="lobstr.co"
+
+[[VALIDATORS]]
+NAME="LOBSTR 2 (Europe)"
+PUBLIC_KEY="GCB2VSADESRV2DDTIVTFLBDI562K6KE3KMKILBHUHUWFXCUBHGQDI7VL"
+ADDRESS="v2.stellar.lobstr.co:11625"
+HISTORY="curl -sf https://archive.v2.stellar.lobstr.co/{0} -o {1}"
+HOME_DOMAIN="lobstr.co"
+
+[[VALIDATORS]]
+NAME="LOBSTR 5 (India)"
+PUBLIC_KEY="GA5STBMV6QDXFDGD62MEHLLHZTPDI77U3PFOD2SELU5RJDHQWBR5NNK7"
+ADDRESS="v5.stellar.lobstr.co:11625"
+HISTORY="curl -sf https://archive.v5.stellar.lobstr.co/{0} -o {1}"
+HOME_DOMAIN="lobstr.co"
+
+[[VALIDATORS]]
+NAME="Boötes"
 PUBLIC_KEY="GCVJ4Z6TI6Z2SOGENSPXDQ2U4RKH3CNQKYUHNSSPYFPNWTLGS6EBH7I2"
 ADDRESS="bootes.publicnode.org:11625"
 HISTORY="curl -sf https://bootes-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="lyra"
-PUBLIC_KEY="GCIXVKNFPKWVMKJKVK2V4NK7D4TC6W3BUMXSIJ365QUAXWBRPPJXIR2Z"
-ADDRESS="lyra.publicnode.org:11625"
-HISTORY="curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
-HOME_DOMAIN="publicnode.org"
-
-[[VALIDATORS]]
-NAME="hercules"
+NAME="Hercules"
 PUBLIC_KEY="GBLJNN3AVZZPG2FYAYTYQKECNWTQYYUUY2KVFN2OUKZKBULXIXBZ4FCT"
 ADDRESS="hercules.publicnode.org:11625"
 HISTORY="curl -sf https://hercules-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="lobstr_1_eu"
-PUBLIC_KEY="GCFONE23AB7Y6C5YZOMKUKGETPIAJA4QOYLS5VNS4JHBGKRZCPYHDLW7"
-ADDRESS="v1.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v1.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr"
+NAME="Lyra"
+PUBLIC_KEY="GCIXVKNFPKWVMKJKVK2V4NK7D4TC6W3BUMXSIJ365QUAXWBRPPJXIR2Z"
+ADDRESS="lyra.publicnode.org:11625"
+HISTORY="curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
+HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="lobstr_2_eu"
-PUBLIC_KEY="GCB2VSADESRV2DDTIVTFLBDI562K6KE3KMKILBHUHUWFXCUBHGQDI7VL"
-ADDRESS="v2.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v2.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr"
+NAME="Blockdaemon Validator 1"
+PUBLIC_KEY="GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
+ADDRESS="stellar-full-validator1.bdnodes.net:11625"
+HISTORY="curl -sf https://stellar-full-history1.bdnodes.net/{0} -o {1}"
+HOME_DOMAIN="stellar.blockdaemon.com"
 
 [[VALIDATORS]]
-NAME="lobstr_5_india"
-PUBLIC_KEY="GA5STBMV6QDXFDGD62MEHLLHZTPDI77U3PFOD2SELU5RJDHQWBR5NNK7"
-ADDRESS="v5.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v5.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr"
-
-[[VALIDATORS]]
-NAME="FT_SCV_2"
-PUBLIC_KEY="GCMSM2VFZGRPTZKPH5OABHGH4F3AVS6XTNJXDGCZ3MKCOSUBH3FL6DOB"
-ADDRESS="stellar2.franklintempleton.com:11625"
-HISTORY="curl -sf https://stellar-history-usc.franklintempleton.com/azuscshf401/{0} -o {1}"
-HOME_DOMAIN="www.franklintempleton.com"
-
-[[VALIDATORS]]
-NAME="FT_SCV_3"
-PUBLIC_KEY="GA7DV63PBUUWNUFAF4GAZVXU2OZMYRATDLKTC7VTCG7AU4XUPN5VRX4A"
-ADDRESS="stellar3.franklintempleton.com:11625"
-HISTORY="curl -sf https://stellar-history-ins.franklintempleton.com/azinsshf401/{0} -o {1}"
-HOME_DOMAIN="www.franklintempleton.com"
-
-[[VALIDATORS]]
-NAME="FT_SCV_1"
-PUBLIC_KEY="GARYGQ5F2IJEBCZJCBNPWNWVDOFK7IBOHLJKKSG2TMHDQKEEC6P4PE4V"
-ADDRESS="stellar1.franklintempleton.com:11625"
-HISTORY="curl -sf https://stellar-history-usw.franklintempleton.com/azuswshf401/{0} -o {1}"
-HOME_DOMAIN="www.franklintempleton.com"
-
-[[VALIDATORS]]
-NAME="satoshipay_de"
-PUBLIC_KEY="GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS="stellar-de-fra.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay"
-
-[[VALIDATORS]]
-NAME="satoshipay_sg"
-PUBLIC_KEY="GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS="stellar-sg-sin.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay"
-
-[[VALIDATORS]]
-NAME="satoshipay_us"
-PUBLIC_KEY="GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS="stellar-us-iowa.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay"
-
-[[VALIDATORS]]
-NAME = "Gamma Node Validator"
-PUBLIC_KEY = "GBF7QOLFPTHUEDUPTT4ZTULDTA3QXDIO75JHKJN2IYD7YGQLYUTR75BT"
-ADDRESS = "gamma.validator.stellar.creit.tech:11625"
-HISTORY = "curl -sf https://gamma-history.validator.stellar.creit.tech/{0} -o {1}"
-HOME_DOMAIN = "stellar.creit.tech"
-
-[[VALIDATORS]]
-NAME = "Alpha Node Validator"
-PUBLIC_KEY = "GBPLJDBFZO2H7QQH7YFCH3HFT6EMC42Z2DNJ2QFROCKETAPY54V4DCZD"
-ADDRESS = "alpha.validator.stellar.creit.tech:11625"
-HISTORY = "curl -sf https://alpha-history.validator.stellar.creit.tech/{0} -o {1}"
-HOME_DOMAIN = "stellar.creit.tech"
-
-[[VALIDATORS]]
-NAME = "Beta Node Validator"
-PUBLIC_KEY = "GDDANSYOYSY5EPSFHBRPCLX6XMHPPLIMHVIDXG6IPQLVVLRI2BN4HMH3"
-ADDRESS = "beta.validator.stellar.creit.tech:11625"
-HISTORY = "curl -sf https://beta-history.validator.stellar.creit.tech/{0} -o {1}"
-HOME_DOMAIN = "stellar.creit.tech"
-
-[[VALIDATORS]]
-NAME="SDF 2"
-PUBLIC_KEY="GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
-ADDRESS="core-live-b.stellar.org:11625"
-HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
-HOME_DOMAIN="sdf"
-
-[[VALIDATORS]]
-NAME="SDF 1"
-PUBLIC_KEY="GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
-ADDRESS="core-live-a.stellar.org:11625"
-HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
-HOME_DOMAIN="sdf"
-
-[[VALIDATORS]]
-NAME="SDF 3"
-PUBLIC_KEY="GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
-ADDRESS="core-live-c.stellar.org:11625"
-HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
-HOME_DOMAIN="sdf"
+NAME="Blockdaemon Validator 2"
+PUBLIC_KEY="GAVXB7SBJRYHSG6KSQHY74N7JAFRL4PFVZCNWW2ARI6ZEKNBJSMSKW7C"
+ADDRESS="stellar-full-validator2.bdnodes.net:11625"
+HISTORY="curl -sf https://stellar-full-history2.bdnodes.net/{0} -o {1}"
+HOME_DOMAIN="stellar.blockdaemon.com"
 
 [[VALIDATORS]]
 NAME="Blockdaemon Validator 3"
 PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
 ADDRESS="stellar-full-validator3.bdnodes.net:11625"
 HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
-HOME_DOMAIN="blockdaemon"
+HOME_DOMAIN="stellar.blockdaemon.com"
 
 [[VALIDATORS]]
-NAME="blockdaemon_2"
-PUBLIC_KEY="GAVXB7SBJRYHSG6KSQHY74N7JAFRL4PFVZCNWW2ARI6ZEKNBJSMSKW7C"
-ADDRESS="stellar-full-validator2.bdnodes.net:11625"
-HISTORY="curl -sf https://stellar-full-history2.bdnodes.net/{0} -o {1}"
-HOME_DOMAIN="blockdaemon"
+NAME="Alpha Node Validator"
+PUBLIC_KEY="GBPLJDBFZO2H7QQH7YFCH3HFT6EMC42Z2DNJ2QFROCKETAPY54V4DCZD"
+ADDRESS="alpha.validator.stellar.creit.tech:11625"
+HISTORY="curl -sf https://alpha-history.validator.stellar.creit.tech/{0} -o {1}"
+HOME_DOMAIN="stellar.creit.tech"
 
 [[VALIDATORS]]
-NAME="blockdaemon_1"
-PUBLIC_KEY="GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
-ADDRESS="stellar-full-validator1.bdnodes.net:11625"
-HISTORY="curl -sf https://stellar-full-history1.bdnodes.net/{0} -o {1}"
-HOME_DOMAIN="blockdaemon"
+NAME="Beta Node Validator"
+PUBLIC_KEY="GDDANSYOYSY5EPSFHBRPCLX6XMHPPLIMHVIDXG6IPQLVVLRI2BN4HMH3"
+ADDRESS="beta.validator.stellar.creit.tech:11625"
+HISTORY="curl -sf https://beta-history.validator.stellar.creit.tech/{0} -o {1}"
+HOME_DOMAIN="stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME="Gamma Node Validator"
+PUBLIC_KEY="GBF7QOLFPTHUEDUPTT4ZTULDTA3QXDIO75JHKJN2IYD7YGQLYUTR75BT"
+ADDRESS="gamma.validator.stellar.creit.tech:11625"
+HISTORY="curl -sf https://gamma-history.validator.stellar.creit.tech/{0} -o {1}"
+HOME_DOMAIN="stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME="OBSRVR Validator 1"
+PUBLIC_KEY="GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS="core-live-1.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME="OBSRVR Validator 2"
+PUBLIC_KEY="GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS="core-live-2.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME="OBSRVR Validator 3"
+PUBLIC_KEY="GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS="core-live-3.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME="FT SCV 1"
+PUBLIC_KEY="GARYGQ5F2IJEBCZJCBNPWNWVDOFK7IBOHLJKKSG2TMHDQKEEC6P4PE4V"
+ADDRESS="stellar1.franklintempleton.com:11625"
+HISTORY="curl -sf https://stellar-history1.franklintempleton.com/history1/{0} -o {1}"
+HOME_DOMAIN="www.franklintempleton.com"
+
+[[VALIDATORS]]
+NAME="FT SCV 2"
+PUBLIC_KEY="GCMSM2VFZGRPTZKPH5OABHGH4F3AVS6XTNJXDGCZ3MKCOSUBH3FL6DOB"
+ADDRESS="stellar2.franklintempleton.com:11625"
+HISTORY="curl -sf https://stellar-history2.franklintempleton.com/history2/{0} -o {1}"
+HOME_DOMAIN="www.franklintempleton.com"
+
+[[VALIDATORS]]
+NAME="FT SCV 3"
+PUBLIC_KEY="GA7DV63PBUUWNUFAF4GAZVXU2OZMYRATDLKTC7VTCG7AU4XUPN5VRX4A"
+ADDRESS="stellar3.franklintempleton.com:11625"
+HISTORY="curl -sf https://stellar-history3.franklintempleton.com/history3/{0} -o {1}"
+HOME_DOMAIN="www.franklintempleton.com"
+
+[[VALIDATORS]]
+NAME="SDF 1"
+PUBLIC_KEY="GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
+ADDRESS="core-live-a.stellar.org:11625"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
+HOME_DOMAIN="www.stellar.org"
+
+[[VALIDATORS]]
+NAME="SDF 2"
+PUBLIC_KEY="GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
+ADDRESS="core-live-b.stellar.org:11625"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+HOME_DOMAIN="www.stellar.org"
+
+[[VALIDATORS]]
+NAME="SDF 3"
+PUBLIC_KEY="GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
+ADDRESS="core-live-c.stellar.org:11625"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
+HOME_DOMAIN="www.stellar.org"


### PR DESCRIPTION
This PR updates the `[[VALIDATORS]]` sections in the bundled stellar-core configs to match the current network. The validators are sorted as in stellar/quickstart#956.