### PR TITLE
internal/db2/history: rewrite /assets pagination as bounded CTE merge query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Improved `/assets` endpoint performance by replacing non-sargable pagination over a `FULL OUTER JOIN` with a bounded CTE merge query that restores index-backed filtering and ordering.
+
 ## 27.0.0
 
 **This release adds support for Protocol 27**

--- a/internal/db2/history/asset_stats.go
+++ b/internal/db2/history/asset_stats.go
@@ -511,10 +511,10 @@ func (q *Q) GetAssetStats(ctx context.Context, assetCode, assetIssuer string, pa
 	}
 
 	expAssetStatsSQL = expAssetStatsSQL.
-		OrderBy("(exp_asset_stats.asset_code, exp_asset_stats.asset_issuer) " + orderBy).
+		OrderBy("exp_asset_stats.asset_code "+orderBy, "exp_asset_stats.asset_issuer "+orderBy).
 		Limit(page.Limit)
 	contractOnlySQL = contractOnlySQL.
-		OrderBy("(asset_contracts.asset_code, asset_contracts.asset_issuer) " + orderBy).
+		OrderBy("asset_contracts.asset_code "+orderBy, "asset_contracts.asset_issuer "+orderBy).
 		Limit(page.Limit)
 
 	expAssetStatsCTE, expAssetStatsArgs, err := expAssetStatsSQL.ToSql()
@@ -553,6 +553,8 @@ func (q *Q) GetAssetStats(ctx context.Context, assetCode, assetIssuer string, pa
 	args = append(args, page.Limit)
 
 	var results []AssetAndContractStat
+	// Add explicit query type for prometheus metrics, since we use raw sql.
+	ctx = context.WithValue(ctx, &db.QueryTypeContextKey, db.SelectQueryType)
 	if err := q.SelectRaw(ctx, &results, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "could not run select query: %s", sql)
 	}

--- a/internal/db2/history/asset_stats.go
+++ b/internal/db2/history/asset_stats.go
@@ -435,32 +435,6 @@ func (q *Q) GetAssetStats(ctx context.Context, assetCode, assetIssuer string, pa
 	//
 	// (3) is stored in the contract_asset_stats table and is derived by ingesting SAC contract balances.
 	//
-	// All 3 tables are joined in the query below to compute the desired list of AssetAndContractStat
-	// entries.
-	sql := sq.Select("COALESCE(exp_asset_stats.asset_type, asset_contracts.asset_type) as asset_type, " +
-		"COALESCE(exp_asset_stats.asset_code, asset_contracts.asset_code) as asset_code, " +
-		"COALESCE(exp_asset_stats.asset_issuer, asset_contracts.asset_issuer) as asset_issuer, " +
-		"exp_asset_stats.accounts, " +
-		"exp_asset_stats.balances, " +
-		"asset_contracts.contract_id as contract_id, contract_asset_stats.stat as contracts").
-		From("exp_asset_stats").
-		JoinClause("FULL OUTER JOIN asset_contracts ON " +
-			"exp_asset_stats.asset_type = asset_contracts.asset_type AND " +
-			"exp_asset_stats.asset_code = asset_contracts.asset_code AND " +
-			"exp_asset_stats.asset_issuer = asset_contracts.asset_issuer").
-		LeftJoin("contract_asset_stats ON asset_contracts.contract_id = contract_asset_stats.contract_id")
-	filters := map[string]interface{}{}
-	if assetCode != "" {
-		filters["COALESCE(exp_asset_stats.asset_code, asset_contracts.asset_code)"] = assetCode
-	}
-	if assetIssuer != "" {
-		filters["COALESCE(exp_asset_stats.asset_issuer, asset_contracts.asset_issuer)"] = assetIssuer
-	}
-
-	if len(filters) > 0 {
-		sql = sql.Where(filters)
-	}
-
 	var cursorComparison, orderBy string
 	switch page.Order {
 	case "asc":
@@ -471,21 +445,119 @@ func (q *Q) GetAssetStats(ctx context.Context, assetCode, assetIssuer string, pa
 		return nil, fmt.Errorf("invalid page order %s", page.Order)
 	}
 
+	cursorCode, cursorIssuer := "", ""
 	if page.Cursor != "" {
-		cursorCode, cursorIssuer, err := parseAssetStatsCursor(page.Cursor)
+		var err error
+		cursorCode, cursorIssuer, err = parseAssetStatsCursor(page.Cursor)
 		if err != nil {
 			return nil, err
 		}
-
-		sql = sql.Where("((COALESCE(exp_asset_stats.asset_code, asset_contracts.asset_code), COALESCE(exp_asset_stats.asset_issuer, asset_contracts.asset_issuer)) "+cursorComparison+" (?,?))", cursorCode, cursorIssuer)
 	}
 
-	sql = sql.OrderBy("(COALESCE(exp_asset_stats.asset_code, asset_contracts.asset_code), COALESCE(exp_asset_stats.asset_issuer, asset_contracts.asset_issuer)) " + orderBy).Limit(page.Limit)
+	expAssetStatsSQL := sq.Select(
+		"exp_asset_stats.asset_type as asset_type",
+		"exp_asset_stats.asset_code as asset_code",
+		"exp_asset_stats.asset_issuer as asset_issuer",
+		"exp_asset_stats.accounts",
+		"exp_asset_stats.balances",
+		"asset_contracts.contract_id as contract_id",
+		"contract_asset_stats.stat as contracts",
+	).
+		From("exp_asset_stats").
+		LeftJoin("asset_contracts ON " +
+			"exp_asset_stats.asset_type = asset_contracts.asset_type AND " +
+			"exp_asset_stats.asset_code = asset_contracts.asset_code AND " +
+			"exp_asset_stats.asset_issuer = asset_contracts.asset_issuer").
+		LeftJoin("contract_asset_stats ON asset_contracts.contract_id = contract_asset_stats.contract_id")
+
+	contractOnlySQL := sq.Select(
+		"asset_contracts.asset_type as asset_type",
+		"asset_contracts.asset_code as asset_code",
+		"asset_contracts.asset_issuer as asset_issuer",
+		`'{"authorized":0,"authorized_to_maintain_liabilities":0,"claimable_balances":0,"liquidity_pools":0,"unauthorized":0}'::jsonb as accounts`,
+		`'{"authorized":"0","authorized_to_maintain_liabilities":"0","claimable_balances":"0","liquidity_pools":"0","unauthorized":"0"}'::jsonb as balances`,
+		"asset_contracts.contract_id as contract_id",
+		"contract_asset_stats.stat as contracts",
+	).
+		From("asset_contracts").
+		LeftJoin("contract_asset_stats ON asset_contracts.contract_id = contract_asset_stats.contract_id").
+		Where(`NOT EXISTS (
+			SELECT 1
+			FROM exp_asset_stats
+			WHERE exp_asset_stats.asset_type = asset_contracts.asset_type
+				AND exp_asset_stats.asset_code = asset_contracts.asset_code
+				AND exp_asset_stats.asset_issuer = asset_contracts.asset_issuer
+		)`)
+
+	if assetCode != "" {
+		expAssetStatsSQL = expAssetStatsSQL.Where("exp_asset_stats.asset_code = ?", assetCode)
+		contractOnlySQL = contractOnlySQL.Where("asset_contracts.asset_code = ?", assetCode)
+	}
+	if assetIssuer != "" {
+		expAssetStatsSQL = expAssetStatsSQL.Where("exp_asset_stats.asset_issuer = ?", assetIssuer)
+		contractOnlySQL = contractOnlySQL.Where("asset_contracts.asset_issuer = ?", assetIssuer)
+	}
+	if page.Cursor != "" {
+		expAssetStatsSQL = expAssetStatsSQL.Where(
+			"((exp_asset_stats.asset_code, exp_asset_stats.asset_issuer) "+cursorComparison+" (?,?))",
+			cursorCode,
+			cursorIssuer,
+		)
+		contractOnlySQL = contractOnlySQL.Where(
+			"((asset_contracts.asset_code, asset_contracts.asset_issuer) "+cursorComparison+" (?,?))",
+			cursorCode,
+			cursorIssuer,
+		)
+	}
+
+	expAssetStatsSQL = expAssetStatsSQL.
+		OrderBy("(exp_asset_stats.asset_code, exp_asset_stats.asset_issuer) " + orderBy).
+		Limit(page.Limit)
+	contractOnlySQL = contractOnlySQL.
+		OrderBy("(asset_contracts.asset_code, asset_contracts.asset_issuer) " + orderBy).
+		Limit(page.Limit)
+
+	expAssetStatsCTE, expAssetStatsArgs, err := expAssetStatsSQL.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not build exp_asset_stats select query")
+	}
+	contractOnlyCTE, contractOnlyArgs, err := contractOnlySQL.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not build contract-only select query")
+	}
+
+	// fmt.Sprintf is safe here because it only stitches together SQL generated by
+	// Squirrel plus the fixed order keyword chosen from "asc"/"desc". User input
+	// remains in the bound args produced by ToSql().
+	sql := fmt.Sprintf(`
+		WITH exp_rows AS (
+			%s
+		), contract_only_rows AS (
+			%s
+		)
+		SELECT *
+		FROM (
+			SELECT * FROM exp_rows
+			UNION ALL
+			SELECT * FROM contract_only_rows
+		) merged
+		ORDER BY asset_code %s, asset_issuer %s
+		LIMIT ?`,
+		expAssetStatsCTE,
+		contractOnlyCTE,
+		orderBy,
+		orderBy,
+	)
+
+	args := append(expAssetStatsArgs, contractOnlyArgs...)
+	args = append(args, page.Limit)
 
 	var results []AssetAndContractStat
-	if err := q.Select(ctx, &results, sql); err != nil {
-		sqlString, _, _ := sql.ToSql()
-		return nil, errors.Wrapf(err, "could not run select query: %s", sqlString)
+	if err := q.SelectRaw(ctx, &results, sql, args...); err != nil {
+		return nil, errors.Wrapf(err, "could not run select query: %s", sql)
+	}
+	if len(results) == 0 {
+		return nil, nil
 	}
 
 	return results, nil


### PR DESCRIPTION
<details>
    <summary>PR Checklist</summary>

  ### PR Structure

  - [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
  - [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise).
  - [x] This PR's title starts with name of package that is most changed in the PR, ex. services/friendbot, or all or doc if the changes are broad or impact many packages.

  ### Thoroughness

  - [x] This PR adds tests for the most critical parts of the new functionality or fixes.
  - [ ] I've updated any docs (developer docs (https://developers.stellar.org/api/), .md files, etc... affected by this change). Take a look in the docs folder for a given service, like this one (https://github.com/stellar/stellar-horizon/tree/main/internal/docs).

  ### Release planning

  - [x] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant CHANGELOG.md within the component folder structure. For example, if I changed horizon, then I updated (CHANGELOG.md (CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.

  - [ ] I've decided if this PR requires a new major/minor version according to semver (https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next release branch if it's not a patch change.
  </details>

  ### What

  Rewrite internal/db2/history /assets pagination to use a bounded CTE merge query instead of paginating across a FULL OUTER JOIN with COALESCE(...).

  The new query:

  - reads exp_asset_stats rows in one indexed branch
  - reads contract-only asset_contracts rows in a second indexed branch
  - merges them in SQL with CTEs and UNION ALL
  - applies the final ORDER BY and LIMIT over the bounded merged result set

  This preserves the existing response semantics while avoiding full-table scan and sort behavior.

  ### Why

  The previous /assets query paginated over a FULL OUTER JOIN and used COALESCE(...) in both filtering and ordering. That made the query non-sargable, so Postgres could not use the existing indexes effectively.

  For the request:

  
`/assets?asset_code=USDC&asset_issuer=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&limit=1`
the `EXPLAIN ANALYZE` results were:

  Before
```
  Limit  (cost=103.26..3168.04 rows=1 width=596) (actual time=130.211..130.214 rows=1 loops=1)
    Buffers: shared hit=19625
    ->  Nested Loop Left Join  (cost=103.26..30751.01 rows=10 width=596) (actual time=130.210..130.212 rows=1 loops=1)
          Buffers: shared hit=19625
          ->  Hash Full Join  (cost=102.99..30747.92 rows=10 width=501) (actual time=130.184..130.186 rows=1 loops=1)
                Hash Cond: ((exp_asset_stats.asset_type = asset_contracts.asset_type) AND ((exp_asset_stats.asset_code)::text = (asset_contracts.asset_code)::text) AND
                ((exp_asset_stats.asset_issuer)::text = (asset_contracts.asset_issuer)::text))
                Filter: (((COALESCE(exp_asset_stats.asset_code, asset_contracts.asset_code))::text = 'USDC'::text) AND ((COALESCE(exp_asset_stats.asset_issuer,
                asset_contracts.asset_issuer))::text = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'::text))
                Rows Removed by Filter: 334606
                Buffers: shared hit=19618
                ->  Seq Scan on exp_asset_stats  (cost=0.00..27634.62 rows=382262 width=401) (actual time=0.002..68.281 rows=334607 loops=1)
                      Buffers: shared hit=19571
                ->  Hash  (cost=67.36..67.36 rows=2036 width=100) (actual time=0.715..0.715 rows=2033 loops=1)
                      Buckets: 2048  Batches: 1  Memory Usage: 280kB
                      Buffers: shared hit=47
                      ->  Seq Scan on asset_contracts  (cost=0.00..67.36 rows=2036 width=100) (actual time=0.006..0.296 rows=2033 loops=1)
                            Buffers: shared hit=47
          ->  Index Scan using contract_asset_stats_pkey on contract_asset_stats  (cost=0.27..0.31 rows=1 width=87) (actual time=0.021..0.021 rows=1 loops=1)
                Index Cond: (contract_id = asset_contracts.contract_id)
                Buffers: shared hit=7
  Planning:
    Buffers: shared hit=9
  Planning Time: 0.465 ms
  Execution Time: 130.288 ms
```

  After
```
  Limit  (cost=14.13..14.13 rows=1 width=353) (actual time=2.645..2.647 rows=1 loops=1)
    Buffers: shared hit=798 read=2
    I/O Timings: shared read=2.058
    ->  Sort  (cost=14.13..14.13 rows=2 width=353) (actual time=2.644..2.647 rows=1 loops=1)
          Sort Key: exp_asset_stats.asset_code, exp_asset_stats.asset_issuer
          Sort Method: quicksort  Memory: 26kB
          Buffers: shared hit=798 read=2
          I/O Timings: shared read=2.058
          ->  Append  (cost=0.97..14.12 rows=2 width=353) (actual time=2.403..2.625 rows=1 loops=1)
                Buffers: shared hit=795 read=2
                I/O Timings: shared read=2.058
                ->  Limit  (cost=0.97..7.05 rows=1 width=488) (actual time=2.403..2.404 rows=1 loops=1)
                      Buffers: shared hit=396 read=2
                      I/O Timings: shared read=2.058
                      ->  Nested Loop Left Join  (cost=0.97..7.05 rows=1 width=488) (actual time=2.402..2.403 rows=1 loops=1)
                            Buffers: shared hit=396 read=2
                            I/O Timings: shared read=2.058
                            ->  Nested Loop Left Join  (cost=0.70..4.75 rows=1 width=434) (actual time=2.384..2.385 rows=1 loops=1)
                                  Join Filter: (exp_asset_stats.asset_type = asset_contracts.asset_type)
                                  Buffers: shared hit=389 read=2
                                  I/O Timings: shared read=2.058
                                  ->  Index Scan using exp_asset_stats_pkey on exp_asset_stats  (cost=0.42..2.44 rows=1 width=401) (actual time=0.306..0.306 rows=1
                                  loops=1)
                                        Index Cond: (((asset_code)::text = 'USDC'::text) AND ((asset_issuer)::text =
                                        'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'::text))
                                        Buffers: shared hit=388
                                  ->  Index Scan using asset_contracts_pkey on asset_contracts  (cost=0.28..2.30 rows=1 width=100) (actual time=2.076..2.076 rows=1
                                  loops=1)
                                        Index Cond: (((asset_code)::text = 'USDC'::text) AND ((asset_issuer)::text =
                                        'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'::text))
                                        Buffers: shared hit=1 read=2
                                        I/O Timings: shared read=2.058
                            ->  Index Scan using contract_asset_stats_pkey on contract_asset_stats  (cost=0.27..2.29 rows=1 width=87) (actual time=0.016..0.016 rows=1
                            loops=1)
                                  Index Cond: (contract_id = asset_contracts.contract_id)
                                  Buffers: shared hit=7
                ->  Limit  (cost=0.97..7.05 rows=1 width=218) (actual time=0.218..0.219 rows=0 loops=1)
                      Buffers: shared hit=399
                      ->  Nested Loop Anti Join  (cost=0.97..7.05 rows=1 width=218) (actual time=0.218..0.218 rows=0 loops=1)
                            Join Filter: (exp_asset_stats_1.asset_type = asset_contracts_1.asset_type)
                            Buffers: shared hit=399
                            ->  Nested Loop Left Join  (cost=0.55..4.60 rows=1 width=154) (actual time=0.018..0.019 rows=1 loops=1)
                                  Buffers: shared hit=10
                                  ->  Index Scan using asset_contracts_pkey on asset_contracts asset_contracts_1  (cost=0.28..2.30 rows=1 width=100) (actual
                                  time=0.010..0.010 rows=1 loops=1)
                                        Index Cond: (((asset_code)::text = 'USDC'::text) AND ((asset_issuer)::text =
                                        'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'::text))
                                        Buffers: shared hit=3
                                  ->  Index Scan using contract_asset_stats_pkey on contract_asset_stats contract_asset_stats_1  (cost=0.27..2.29 rows=1 width=87)
                                  (actual time=0.007..0.007 rows=1 loops=1)
                                        Index Cond: (contract_id = asset_contracts_1.contract_id)
                                        Buffers: shared hit=7
                            ->  Index Only Scan using exp_asset_stats_pkey on exp_asset_stats exp_asset_stats_1  (cost=0.42..2.44 rows=1 width=68) (actual
                            time=0.198..0.198 rows=1 loops=1)
                                  Index Cond: ((asset_code = 'USDC'::text) AND (asset_issuer = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'::text))
                                  Heap Fetches: 385
                                  Buffers: shared hit=389
  Planning:
    Buffers: shared hit=48 read=4
    I/O Timings: shared read=2.978
  Planning Time: 3.698 ms
  Execution Time: 2.696 ms
```

  This reduces execution time for that request from 130.288 ms to 2.696 ms while changing the plan from full scans plus a full join to bounded index-backed branches.

  ### Known limitations

  - The merged query still performs a final sort, but only over the bounded branch outputs rather than the full joined asset set.
  - The contract-only branch still performs an anti-join check against exp_asset_stats; this is much cheaper than the previous full scan, but it is not free.

