### PR TITLE
Pin integration legs to post-flip rpc image 28.0.0-vnext-200

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -17,7 +17,7 @@ jobs:
       # already-shipped versions against each other.
       core_deb_version: '28.0.0-3486.2332980a1.jammy~buildtests'
       core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
-      stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-unstable-195'
+      stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-200'
       full_matrix: true
 
   integration-p28-pkg:
@@ -27,7 +27,7 @@ jobs:
       protocol_version: '28'
       core_deb_version: '28.0.0-3486.2332980a1.jammy~buildtests'
       core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
-      stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-unstable-195'
+      stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-200'
       full_matrix: true
 
   # integration-p28-src:
@@ -36,7 +36,7 @@ jobs:
   #   with:
   #     protocol_version: '28'
   #     core_git_ref: 'master'
-  #     stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-unstable-195'
+  #     stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-200'
 
   verify-range:
     name: Test (and push) verify-range image


### PR DESCRIPTION
Part of the Protocol 28 GA release train (stellar/go-stellar-sdk#5967).

Replaces the pre-flip `stellar/stellar-rpc:28.0.0-vnext-unstable-195` pin on both integration legs (and the commented-out src leg) with `28.0.0-vnext-200`, which satisfies the merge gate for protocol-next → main:

- built from stellar/stellar-rpc@e6bb90bf — the P28 GA merge commit (post-flip code)
- preflight hosts: released soroban-env-host 28.0.1 (curr) / 27.0.1 (prev), stellar-xdr 9c9c1459
- bundled captive core: GA `stellar-core 28.0.0 (2332980a1)`

Verified by running the image: `stellar-rpc 28.0.0~vnext-e6bb90bf…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)