### PR TITLE
Run full matrix only on pushes to main

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -18,7 +18,10 @@ jobs:
       core_deb_version: '28.0.0-3486.2332980a1.jammy~buildtests'
       core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
       stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-200'
-      full_matrix: true
+      # The full go/postgres matrix runs only on pushes to main since they're
+      # non-blocking and happen in the background. Everyday PRs get the single 
+      # latest-go/latest-pg job.
+      full_matrix: ${{ github.event_name == 'push' }}
 
   integration-p28-pkg:
     name: Integration tests (P28)
@@ -28,7 +31,7 @@ jobs:
       core_deb_version: '28.0.0-3486.2332980a1.jammy~buildtests'
       core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
       stellar_rpc_docker_img: 'stellar/stellar-rpc:28.0.0-vnext-200'
-      full_matrix: true
+      full_matrix: ${{ github.event_name == 'push' }}
 
   # integration-p28-src:
   #   name: Integration tests (P28, core from source)


### PR DESCRIPTION
After internal discussion, we decided to reduce CI churn by only running the full matrix on pushes to `main` since those are non-disruptive "background" jobs.