### PR TITLE
Filter contract data removals on the ledger key

### DIFF
--- a/internal/ingest/processors/asset_stats_processor.go
+++ b/internal/ingest/processors/asset_stats_processor.go
@@ -243,6 +243,11 @@ func (p *AssetStatsProcessor) updateDB(
 		return err
 	}
 
+	// reads the rows RemoveContractAssetBalances is about to delete
+	if err := contractAssetStatSet.ingestRemovedBalances(ctx); err != nil {
+		return err
+	}
+
 	if err := p.assetStatsQ.RemoveContractAssetBalances(ctx, contractAssetStatSet.removedBalances); err != nil {
 		return errors.Wrap(err, "Error removing contract asset balances")
 	}

--- a/internal/ingest/processors/asset_stats_processor.go
+++ b/internal/ingest/processors/asset_stats_processor.go
@@ -68,16 +68,31 @@ func (p *AssetStatsProcessor) ProcessChange(ctx context.Context, change ingest.C
 	case xdr.LedgerEntryTypeTrustline:
 		err = p.assetStatSet.AddTrustline(change)
 	case xdr.LedgerEntryTypeContractData:
-		// only ingest contract data entries which could be relevant to
-		// asset stats
-		ledgerEntry := change.Post
-		if ledgerEntry == nil {
-			ledgerEntry = change.Pre
-		}
-		_, assetFound := sac.AssetFromContractData(*ledgerEntry, p.networkPassphrase)
-		_, _, balanceFound := sac.ContractBalanceFromContractData(*ledgerEntry, p.networkPassphrase)
-		if !assetFound && !balanceFound {
-			return nil
+		// Only ingest contract data entries which could be relevant to
+		// asset stats.
+		//
+		// We care about SAC activity exclusively, but balance provenance cannot
+		// be determined from the entry alone. Thus we propagate balance-looking
+		// changes and validate SACs when possible.
+		if change.Post == nil { // removal
+			if change.Pre == nil { // defensive
+				return nil
+			}
+			// Keys are immutable so we check that over the value on removal.
+			ledgerKey, keyErr := change.Pre.LedgerKey()
+			if keyErr != nil {
+				return errors.Wrap(keyErr, "could not extract ledger key")
+			}
+
+			if !sac.ValidContractBalanceLedgerKey(ledgerKey) {
+				return nil
+			}
+		} else { // create/update
+			_, assetFound := sac.AssetFromContractData(*change.Post, p.networkPassphrase)
+			_, _, balanceFound := sac.ContractBalanceFromContractData(*change.Post, p.networkPassphrase)
+			if !assetFound && !balanceFound { // neither balance nor asset init
+				return nil
+			}
 		}
 		p.contractDataChanges = append(p.contractDataChanges, change)
 	case xdr.LedgerEntryTypeTtl:

--- a/internal/ingest/processors/asset_stats_processor_contract_data_test.go
+++ b/internal/ingest/processors/asset_stats_processor_contract_data_test.go
@@ -1,0 +1,140 @@
+package processors
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/ingest/sac"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-horizon/internal/db2/history"
+)
+
+// runContractDataLedger ingests changes for a single ledger the way live
+// ingestion does, with one AssetStatsProcessor per ledger, and reports the key
+// hashes the processor asked the db to insert into and remove from
+// contract_asset_balances.
+func runContractDataLedger(
+	t *testing.T, ledger uint32, changes ...ingest.Change,
+) (inserted []xdr.Hash, removed []xdr.Hash) {
+	ctx := context.Background()
+	q := &history.MockQAssetStats{}
+
+	q.On("InsertContractAssetBalances", ctx, mock.Anything).Run(func(args mock.Arguments) {
+		for _, row := range args.Get(1).([]history.ContractAssetBalance) {
+			var keyHash xdr.Hash
+			copy(keyHash[:], row.KeyHash)
+			inserted = append(inserted, keyHash)
+		}
+	}).Return(nil).Maybe()
+	q.On("RemoveContractAssetBalances", ctx, mock.Anything).Run(func(args mock.Arguments) {
+		removed = append(removed, args.Get(1).([]xdr.Hash)...)
+	}).Return(nil).Maybe()
+
+	q.On("InsertAssetContracts", ctx, mock.Anything).Return(nil).Maybe()
+	q.On("UpdateContractAssetBalanceAmounts", ctx, mock.Anything, mock.Anything).Return(nil).Maybe()
+	q.On("UpdateContractAssetBalanceExpirations", ctx, mock.Anything, mock.Anything).Return(nil).Maybe()
+	q.On("UpdateAssetContractExpirations", ctx, mock.Anything, mock.Anything).Return(nil).Maybe()
+	q.On("DeleteContractAssetBalancesExpiringAt", ctx, mock.Anything).
+		Return([]history.ContractAssetBalance{}, nil).Maybe()
+	q.On("DeleteAssetContractsExpiringAt", ctx, mock.Anything).Return(int64(0), nil).Maybe()
+	q.On("GetContractAssetStat", ctx, mock.Anything).
+		Return(history.ContractAssetStatRow{}, sql.ErrNoRows).Maybe()
+	q.On("InsertContractAssetStat", ctx, mock.Anything).Return(int64(1), nil).Maybe()
+
+	p := NewAssetStatsProcessor(q, "passphrase", false, ledger)
+	for _, change := range changes {
+		assert.NoError(t, p.ProcessChange(ctx, change))
+	}
+	assert.NoError(t, p.Commit(ctx))
+
+	return inserted, removed
+}
+
+func contractDataChange(pre, post *xdr.LedgerEntryData) ingest.Change {
+	change := ingest.Change{Type: xdr.LedgerEntryTypeContractData}
+	if pre != nil {
+		change.Pre = &xdr.LedgerEntry{Data: *pre}
+	}
+	if post != nil {
+		change.Post = &xdr.LedgerEntry{Data: *post}
+	}
+	return change
+}
+
+func ttlCreate(keyHash xdr.Hash, liveUntil uint32) ingest.Change {
+	return ingest.Change{
+		Type: xdr.LedgerEntryTypeTtl,
+		Post: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTtl,
+			Ttl: &xdr.TtlEntry{
+				KeyHash:            keyHash,
+				LiveUntilLedgerSeq: xdr.Uint32(liveUntil),
+			},
+		}},
+	}
+}
+
+// TestContractDataRemovalFilteredByLedgerKey covers removal of a contract data
+// entry whose value was rewritten, at the same ledger key, into something which
+// no longer resembles a Stellar Asset Contract balance. contract_asset_balances
+// is keyed on the ledger key, so a row's lifetime follows the key rather than
+// the value, and removals are filtered on that basis.
+func TestContractDataRemovalFilteredByLedgerKey(t *testing.T) {
+	assetContractID := [32]byte{0xAA}
+	holderID := [32]byte{0xBB}
+
+	balance := sac.BalanceToContractData(assetContractID, holderID, 1000)
+	keyHash := getKeyHashForBalance(t, assetContractID, holderID)
+
+	// value rewritten, ledger key unchanged
+	rewritten := *balance.ContractData
+	val := xdr.Uint32(1)
+	rewritten.Val = xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: &val}
+	rewrittenData := xdr.LedgerEntryData{
+		Type:         xdr.LedgerEntryTypeContractData,
+		ContractData: &rewritten,
+	}
+
+	_, _, ok := sac.ContractBalanceFromContractData(
+		xdr.LedgerEntry{Data: rewrittenData}, "passphrase",
+	)
+	assert.False(t, ok, "rewritten entry must no longer resemble a balance")
+
+	inserted, _ := runContractDataLedger(t, 100,
+		contractDataChange(nil, &balance),
+		ttlCreate(keyHash, 5000),
+	)
+	assert.Equal(t, []xdr.Hash{keyHash}, inserted)
+
+	_, removed := runContractDataLedger(t, 101, contractDataChange(&rewrittenData, nil))
+	assert.Equal(t, []xdr.Hash{keyHash}, removed)
+}
+
+// TestContractDataRemovalOfUnrelatedKeyIgnored covers the other side of that
+// filter: a removal whose ledger key could never have identified a row in
+// contract_asset_balances is still skipped.
+func TestContractDataRemovalOfUnrelatedKeyIgnored(t *testing.T) {
+	contractID := xdr.ContractId{0xAA}
+	key := xdr.ScSymbol("other")
+	data := xdr.LedgerEntryData{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.ContractDataEntry{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &contractID,
+			},
+			Key:        xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &key},
+			Durability: xdr.ContractDataDurabilityPersistent,
+			Val:        xdr.ScVal{Type: xdr.ScValTypeScvVoid},
+		},
+	}
+
+	_, removed := runContractDataLedger(t, 100, contractDataChange(&data, nil))
+	assert.Empty(t, removed)
+}

--- a/internal/ingest/processors/asset_stats_processor_contract_data_test.go
+++ b/internal/ingest/processors/asset_stats_processor_contract_data_test.go
@@ -18,10 +18,11 @@ import (
 // runContractDataLedger ingests changes for a single ledger the way live
 // ingestion does, with one AssetStatsProcessor per ledger, and reports the key
 // hashes the processor asked the db to insert into and remove from
-// contract_asset_balances.
+// contract_asset_balances, plus the contract asset stats it wrote. storedRows is
+// what contract_asset_balances already holds for the keys the ledger removes.
 func runContractDataLedger(
-	t *testing.T, ledger uint32, changes ...ingest.Change,
-) (inserted []xdr.Hash, removed []xdr.Hash) {
+	t *testing.T, ledger uint32, storedRows []history.ContractAssetBalance, changes ...ingest.Change,
+) (inserted []xdr.Hash, removed []xdr.Hash, statInserts []history.ContractAssetStatRow) {
 	ctx := context.Background()
 	q := &history.MockQAssetStats{}
 
@@ -36,6 +37,8 @@ func runContractDataLedger(
 		removed = append(removed, args.Get(1).([]xdr.Hash)...)
 	}).Return(nil).Maybe()
 
+	q.On("GetContractAssetBalances", ctx, mock.Anything).Return(storedRows, nil).Maybe()
+
 	q.On("InsertAssetContracts", ctx, mock.Anything).Return(nil).Maybe()
 	q.On("UpdateContractAssetBalanceAmounts", ctx, mock.Anything, mock.Anything).Return(nil).Maybe()
 	q.On("UpdateContractAssetBalanceExpirations", ctx, mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -45,7 +48,9 @@ func runContractDataLedger(
 	q.On("DeleteAssetContractsExpiringAt", ctx, mock.Anything).Return(int64(0), nil).Maybe()
 	q.On("GetContractAssetStat", ctx, mock.Anything).
 		Return(history.ContractAssetStatRow{}, sql.ErrNoRows).Maybe()
-	q.On("InsertContractAssetStat", ctx, mock.Anything).Return(int64(1), nil).Maybe()
+	q.On("InsertContractAssetStat", ctx, mock.Anything).Run(func(args mock.Arguments) {
+		statInserts = append(statInserts, args.Get(1).(history.ContractAssetStatRow))
+	}).Return(int64(1), nil).Maybe()
 
 	p := NewAssetStatsProcessor(q, "passphrase", false, ledger)
 	for _, change := range changes {
@@ -53,7 +58,7 @@ func runContractDataLedger(
 	}
 	assert.NoError(t, p.Commit(ctx))
 
-	return inserted, removed
+	return inserted, removed, statInserts
 }
 
 func contractDataChange(pre, post *xdr.LedgerEntryData) ingest.Change {
@@ -71,6 +76,19 @@ func ttlCreate(keyHash xdr.Hash, liveUntil uint32) ingest.Change {
 	return ingest.Change{
 		Type: xdr.LedgerEntryTypeTtl,
 		Post: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTtl,
+			Ttl: &xdr.TtlEntry{
+				KeyHash:            keyHash,
+				LiveUntilLedgerSeq: xdr.Uint32(liveUntil),
+			},
+		}},
+	}
+}
+
+func ttlRemove(keyHash xdr.Hash, liveUntil uint32) ingest.Change {
+	return ingest.Change{
+		Type: xdr.LedgerEntryTypeTtl,
+		Pre: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
 			Type: xdr.LedgerEntryTypeTtl,
 			Ttl: &xdr.TtlEntry{
 				KeyHash:            keyHash,
@@ -106,13 +124,13 @@ func TestContractDataRemovalFilteredByLedgerKey(t *testing.T) {
 	)
 	assert.False(t, ok, "rewritten entry must no longer resemble a balance")
 
-	inserted, _ := runContractDataLedger(t, 100,
+	inserted, _, _ := runContractDataLedger(t, 100, nil,
 		contractDataChange(nil, &balance),
 		ttlCreate(keyHash, 5000),
 	)
 	assert.Equal(t, []xdr.Hash{keyHash}, inserted)
 
-	_, removed := runContractDataLedger(t, 101, contractDataChange(&rewrittenData, nil))
+	_, removed, _ := runContractDataLedger(t, 101, nil, contractDataChange(&rewrittenData, nil))
 	assert.Equal(t, []xdr.Hash{keyHash}, removed)
 }
 
@@ -135,6 +153,72 @@ func TestContractDataRemovalOfUnrelatedKeyIgnored(t *testing.T) {
 		},
 	}
 
-	_, removed := runContractDataLedger(t, 100, contractDataChange(&data, nil))
+	_, removed, _ := runContractDataLedger(t, 100, nil, contractDataChange(&data, nil))
 	assert.Empty(t, removed)
+}
+
+// TestContractDataRemovalUsesStoredAmount covers the stat delta for a removed
+// balance whose value was rewritten before it was removed. The amount comes from
+// the stored row, since the value on the removed entry no longer describes what
+// was counted.
+func TestContractDataRemovalUsesStoredAmount(t *testing.T) {
+	assetContractID := [32]byte{0xAA}
+	holderID := [32]byte{0xBB}
+
+	balance := sac.BalanceToContractData(assetContractID, holderID, 1000)
+	keyHash := getKeyHashForBalance(t, assetContractID, holderID)
+
+	// value rewritten, ledger key unchanged
+	rewritten := *balance.ContractData
+	val := xdr.Uint32(1)
+	rewritten.Val = xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: &val}
+	rewrittenData := xdr.LedgerEntryData{
+		Type:         xdr.LedgerEntryTypeContractData,
+		ContractData: &rewritten,
+	}
+
+	storedRows := []history.ContractAssetBalance{
+		{
+			KeyHash:          keyHash[:],
+			ContractID:       assetContractID[:],
+			Amount:           "1000",
+			ExpirationLedger: 5000,
+		},
+	}
+
+	_, removed, statInserts := runContractDataLedger(t, 101, storedRows,
+		contractDataChange(&rewrittenData, nil),
+		ttlRemove(keyHash, 5000),
+	)
+
+	assert.Equal(t, []xdr.Hash{keyHash}, removed)
+	assert.Equal(t, []history.ContractAssetStatRow{
+		{
+			ContractID: assetContractID[:],
+			Stat: history.ContractStat{
+				ActiveBalance: "-1000",
+				ActiveHolders: -1,
+			},
+		},
+	}, statInserts)
+}
+
+// TestContractDataRemovalWithoutStoredRowLeavesStats covers a removal whose entry
+// does resemble a balance but which was never ingested as one, because it only
+// came to resemble a balance after it was created. With no stored row there is no
+// stat to adjust, whatever the removed entry's value looks like.
+func TestContractDataRemovalWithoutStoredRowLeavesStats(t *testing.T) {
+	assetContractID := [32]byte{0xAA}
+	holderID := [32]byte{0xBB}
+
+	balance := sac.BalanceToContractData(assetContractID, holderID, 100)
+	keyHash := getKeyHashForBalance(t, assetContractID, holderID)
+
+	_, removed, statInserts := runContractDataLedger(t, 102, nil,
+		contractDataChange(&balance, nil),
+		ttlRemove(keyHash, 5000),
+	)
+
+	assert.Equal(t, []xdr.Hash{keyHash}, removed)
+	assert.Empty(t, statInserts)
 }

--- a/internal/ingest/processors/asset_stats_processor_test.go
+++ b/internal/ingest/processors/asset_stats_processor_test.go
@@ -1014,6 +1014,10 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveContractBalance() {
 	usdAssetContractStat.Stat.ActiveHolders = 0
 	usdAssetContractStat.Stat.ActiveBalance = "0"
 	s.mockQ.On("RemoveAssetContractStat", s.ctx, usdID[:]).Return(int64(1), nil).Once()
+	s.mockQ.On("GetContractAssetBalances", s.ctx, []xdr.Hash{keyHash}).
+		Return([]history.ContractAssetBalance{
+			{KeyHash: keyHash[:], ContractID: usdID[:], Amount: "200", ExpirationLedger: 2234},
+		}, nil).Once()
 	s.mockQ.On("RemoveContractAssetBalances", s.ctx, []xdr.Hash{keyHash}).
 		Return(nil).Once()
 	s.mockQ.On("UpdateContractAssetBalanceAmounts", s.ctx, []xdr.Hash{}, []string{}).

--- a/internal/ingest/processors/contract_asset_stats.go
+++ b/internal/ingest/processors/contract_asset_stats.go
@@ -30,6 +30,7 @@ func (v assetContractStatValue) ConvertToHistoryObject() history.ContractAssetSt
 }
 
 type contractAssetBalancesQ interface {
+	GetContractAssetBalances(ctx context.Context, keys []xdr.Hash) ([]history.ContractAssetBalance, error)
 	DeleteContractAssetBalancesExpiringAt(ctx context.Context, ledger uint32) ([]history.ContractAssetBalance, error)
 }
 
@@ -208,29 +209,11 @@ func (s *ContractAssetStatSet) ingestContractAssetBalance(change ingest.Change) 
 		if err != nil {
 			return err
 		}
-		// We always include the key hash in s.removedBalances even
-		// if the ledger entry is not a valid balance ledger entry.
-		// It's possible that a contract is able to forge a created
-		// balance ledger entry which matches the Stellar Asset Contract
-		// and later on the ledger entry is updated to an invalid state.
-		// In such a scenario we still want to remove the balance ledger
-		// entry from our db when the entry is removed from the ledger.
+		// The key hash is recorded whether or not the entry still resembles a
+		// balance, since rows are keyed on the ledger key. The stat delta is
+		// applied by ingestRemovedBalances from the stored row, because the
+		// value here is not a reliable record of what was counted.
 		s.removedBalances = append(s.removedBalances, keyHash)
-
-		_, preAmt, ok := sac.ContractBalanceFromContractData(*change.Pre, s.networkPassphrase)
-		if !ok {
-			return nil
-		}
-
-		expirationLedger, ok := s.removedExpirationEntries[keyHash]
-		if !ok || expirationLedger < s.currentLedger {
-			return nil
-		}
-
-		stat := s.getContractAssetStat(*pContractID)
-		stat.activeHolders--
-		stat.activeBalance = new(big.Int).Sub(stat.activeBalance, preAmt)
-		s.maybeAddContractAssetStat(*pContractID, stat)
 	case change.Pre != nil && change.Post != nil: // updated
 		pContractID := change.Pre.Data.MustContractData().Contract.ContractId
 		if pContractID == nil {
@@ -266,6 +249,45 @@ func (s *ContractAssetStatSet) ingestContractAssetBalance(change ingest.Change) 
 	default:
 		return errors.Errorf("unexpected change Pre: %v Post: %v", change.Pre, change.Post)
 	}
+	return nil
+}
+
+// ingestRemovedBalances applies the stat delta for balances whose ledger entry
+// was removed, taking the amount from the stored row rather than from the removed
+// entry. A removed key with no stored row was either never ingested as a balance
+// or was already accounted for when its row was reaped on expiry, and needs no
+// adjustment either way.
+//
+// This must run before RemoveContractAssetBalances, which deletes the rows it
+// reads.
+func (s *ContractAssetStatSet) ingestRemovedBalances(ctx context.Context) error {
+	if len(s.removedBalances) == 0 {
+		return nil
+	}
+
+	rows, err := s.assetStatsQ.GetContractAssetBalances(ctx, s.removedBalances)
+	if err != nil {
+		return errors.Wrap(err, "Error fetching removed contract asset balances")
+	}
+
+	for _, row := range rows {
+		amt, ok := new(big.Int).SetString(row.Amount, 10)
+		if !ok {
+			return errors.Errorf(
+				"contract balance %v has invalid amount: %v",
+				row.KeyHash,
+				row.Amount,
+			)
+		}
+
+		var contractID xdr.ContractId
+		copy(contractID[:], row.ContractID)
+		stat := s.getContractAssetStat(contractID)
+		stat.activeHolders--
+		stat.activeBalance.Sub(stat.activeBalance, amt)
+		s.maybeAddContractAssetStat(contractID, stat)
+	}
+
 	return nil
 }
 

--- a/internal/ingest/processors/contract_asset_stats_test.go
+++ b/internal/ingest/processors/contract_asset_stats_test.go
@@ -416,8 +416,9 @@ func TestRemoveContractData(t *testing.T) {
 	usdcID, err := usdcAsset.ContractID("passphrase")
 	assert.NoError(t, err)
 
+	mockQ := &history.MockQAssetStats{}
 	set := NewContractAssetStatSet(
-		&history.MockQAssetStats{},
+		mockQ,
 		"passphrase",
 		map[xdr.Hash]uint32{},
 		map[xdr.Hash]uint32{},
@@ -426,7 +427,6 @@ func TestRemoveContractData(t *testing.T) {
 	)
 
 	keyHash := getKeyHashForBalance(t, usdcID, [32]byte{})
-	set.removedExpirationEntries[keyHash] = 170
 	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
@@ -436,7 +436,6 @@ func TestRemoveContractData(t *testing.T) {
 	assert.NoError(t, err)
 
 	keyHash1 := getKeyHashForBalance(t, usdcID, [32]byte{1})
-	set.removedExpirationEntries[keyHash1] = 100
 	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
@@ -457,15 +456,25 @@ func TestRemoveContractData(t *testing.T) {
 	assert.Equal(t, []xdr.Hash{keyHash, keyHash1, keyHash2}, set.removedBalances)
 	assert.Empty(t, set.createdAssetContracts)
 
+	// keyHash1 has no stored row, so it contributes nothing to the stats
+	ctx := context.Background()
+	mockQ.On("GetContractAssetBalances", ctx, []xdr.Hash{keyHash, keyHash1, keyHash2}).
+		Return([]history.ContractAssetBalance{
+			{KeyHash: keyHash[:], ContractID: usdcID[:], Amount: "50", ExpirationLedger: 170},
+			{KeyHash: keyHash2[:], ContractID: usdcID[:], Amount: "34", ExpirationLedger: 170},
+		}, nil).Once()
+	assert.NoError(t, set.ingestRemovedBalances(ctx))
+
 	assert.ElementsMatch(t, set.GetContractStats(), []history.ContractAssetStatRow{
 		{
 			ContractID: usdcID[:],
 			Stat: history.ContractStat{
-				ActiveBalance: "-50",
-				ActiveHolders: -1,
+				ActiveBalance: "-84",
+				ActiveHolders: -2,
 			},
 		},
 	})
+	mockQ.AssertExpectations(t)
 }
 
 func TestIngestExpiredBalances(t *testing.T) {


### PR DESCRIPTION
`AssetStatsProcessor` filters contract data changes that are relevant to asset stats by inspecting the entry's value. A removal has no new value, so the check falls back to the entry's last value which may or may not be from an SAC.